### PR TITLE
Add devDependency on `resolve-from`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "memory-fs": "^0.4.1",
     "node-pre-gyp": "^0.12.0",
     "resolve": "^1.10.0",
+    "resolve-from": "^3.0.0",
     "rollup-pluginutils": "^2.3.3",
     "socket.io-client": "^2.2.0",
     "webpack": "^4.29.0",


### PR DESCRIPTION
It's used in a test but was not listed in the dependencies, so
`resolve-from` was not guaranteed to be available, especially with npm
clients like pnpm that do not hoist transitive dependencies into a flat
node_modules structure.