### PR TITLE
Add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@zeit/webpack-asset-relocator-loader",
+  "description": "Asset relocation loader used in ncc for performing Node.js builds while emitting and relocating any asset references.",
   "version": "0.7.2",
   "repository": "zeit/webpack-asset-relocator-loader",
   "license": "MIT",


### PR DESCRIPTION

If `description` is missing from package.json, the tools that use it (like `$ npm info` and [npmhub](https://github.com/npmhub/npmhub)) will unsuccessfully try to parse the readme and get nonsense.

### Before

```
$ npm info @zeit/webpack-asset-relocator-loader

@zeit/webpack-asset-relocator-loader@0.7.2 | MIT | deps: none | versions: 54
[![Build Status](https://circleci.com/gh/zeit/webpack-asset-relocator-loader.svg?&style=shield)](https://circleci.com/gh/zeit/workflows/webpack-asset-relocator-loader) [![codecov](https://codecov.io/gh/zeit/webpack-asset-relocator-loader/branch/master/gra
https://github.com/zeit/webpack-asset-relocator-loader#readme

... etc
```

<img width="731" alt="" src="https://user-images.githubusercontent.com/1402241/84299854-b5432a80-ab51-11ea-9ca4-a58282b8faba.png">


### After


```
$ npm info @zeit/webpack-asset-relocator-loader

@zeit/webpack-asset-relocator-loader@0.7.2 | MIT | deps: none | versions: 54
Asset relocation loader used in ncc for performing Node.js builds while emitting and relocating any asset references.
https://github.com/zeit/webpack-asset-relocator-loader#readme

... etc
```