### PR TITLE
Webpack 5 updates

### DIFF
--- a/src/utils/sharedlib-emit.js
+++ b/src/utils/sharedlib-emit.js
@@ -40,7 +40,7 @@ module.exports = async function (pkgPath, assetState, assetBase, emitFile, debug
       assetState.assetPermissions[file.substr(pkgPath.length)] = stats.mode;
       if (debugLog)
         console.log('Emitting ' + file + ' for shared library support in ' + pkgPath);
-      emitFile(assetBase + file.substr(pkgPath.length), source);
+      emitFile(assetBase + file.substr(pkgPath.length + 1), source);
     }
   }));
 };


### PR DESCRIPTION
This gets the relocator loader running on Webpack 5 without errors or deprecation warnings.

It might be sensible to keep the tests here to Webpack 4 for compat, but I'm open to running the Webpack 5 upgrade here too.