### PR TITLE
feat: extend asset metadata to include original path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,13 +66,13 @@ Assets will be emitted using `emitAsset`, with their references updated in the c
 
 Asset symlinks and permissions are maintained in the loader, but aren't passed to Webpack as `emit` doesn't support these.
 
-This information can be obtained from the loader through the API calls `getAssetPermissions()` and `getSymlinks()`:
+This information can be obtained from the loader through the API calls `getAssetMeta()` and `getSymlinks()`:
 
 ```js
 const relocateLoader = require('webpack-asset-relocator-loader');
 
 webpack({...}).run((err, stats) => {
-  const assetPermissions = relocateLoader.getAssetPermissions();
+  const assetMeta = relocateLoader.getAssetMeta();
   const symlinks = relocateLoader.getSymlinks();
 });
 ```

--- a/src/utils/sharedlib-emit.js
+++ b/src/utils/sharedlib-emit.js
@@ -37,7 +37,7 @@ module.exports = async function (pkgPath, assetState, assetBase, emitFile, debug
       assetState.assetSymlinks[assetBase + file.substr(pkgPath.length + 1)] = path.relative(baseDir, path.resolve(baseDir, symlink));
     }
     else {
-      assetState.assetPermissions[file.substr(pkgPath.length)] = stats.mode;
+      assetState.assetMeta[file.substr(pkgPath.length)] = { path: file, permissions: stats.mode };
       if (debugLog)
         console.log('Emitting ' + file + ' for shared library support in ' + pkgPath);
       emitFile(assetBase + file.substr(pkgPath.length + 1), source);


### PR DESCRIPTION
This renames `relocatorLoader.getAssetPermissions` to `relocatorLoader.getAssetMeta` which then includes both `permissions` and `path` providing the original asset path.

This is necessary to enable subsequent asset processing operations.

Strictly speaking this is a major change so should probably be a bump.