### PR TITLE
Subbuild compilations

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -1253,12 +1253,12 @@ module.exports = async function (content, map) {
 };
 
 module.exports.raw = true;
-module.exports.getAssetMeta = function(assetName, compilation) {
+module.exports.getAssetMeta = function (assetName, compilation) {
   const state = compilation ? stateMap.get(compilation) : lastState;
   if (state)
     return state.assetMeta[assetName];
 };
-module.exports.getSymlinks = function(compilation) {
+module.exports.getSymlinks = function (compilation) {
   const state = compilation ? stateMap.get(compilation) : lastState;
   if (state)
     return lastState.assetSymlinks;

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -1253,12 +1253,14 @@ module.exports = async function (content, map) {
 };
 
 module.exports.raw = true;
-module.exports.getAssetMeta = function(assetName) {
-  if (lastState)
-    return lastState.assetMeta[assetName];
+module.exports.getAssetMeta = function(assetName, compilation) {
+  const state = compilation ? stateMap.get(compilation) : lastState;
+  if (state)
+    return state.assetMeta[assetName];
 };
-module.exports.getSymlinks = function() {
-  if (lastState)
+module.exports.getSymlinks = function(compilation) {
+  const state = compilation ? stateMap.get(compilation) : lastState;
+  if (state)
     return lastState.assetSymlinks;
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,7 +114,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
       for (const asset of assets) {
         if (asset.indexOf('.') === -1)
           continue;
-        const assetMeta = relocateLoader.getAssetMeta(asset);
+        const assetMeta = relocateLoader.getAssetMeta(asset, compiler.compilation);
         expect(assetMeta.permissions).toBeGreaterThan(0);
         expect(typeof assetMeta.path).toBe('string');
       }


### PR DESCRIPTION
When running subbuild compilations in ncc, we need to be able to get the asset lists for different compilations. This permits a new `compilation` argument to the asset functions that allows passing this information, while remaining backwards compatible with the existing API so it is just a patch release.