### PR TITLE
Fixup exact dir case in directory deduping

### DIFF
--- a/src/utils/dedupe-names.js
+++ b/src/utils/dedupe-names.js
@@ -4,7 +4,7 @@ module.exports = getUniqueAssetName;
 function getUniqueAssetName (assetName, assetPath, assetNames, isDir) {
   const ext = path.extname(assetName);
   let uniqueName = assetName, i = 0;
-  while ((!isDir && uniqueName in assetNames ||
+  while ((uniqueName in assetNames ||
           (isDir && Object.keys(assetNames).some(assetName => assetName.startsWith(uniqueName + path.sep))))
       && assetNames[uniqueName] !== assetPath) {
     uniqueName = assetName.substr(0, assetName.length - ext.length) + ++i + ext;

--- a/test/unit/dirname-emit-dedupe/input.js
+++ b/test/unit/dirname-emit-dedupe/input.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
-console.log(fs.readdirSync(__dirname + '/dir/asset1.txt'));
-console.log(fs.readdirSync(getDirAsset('asset2')));
+console.log(fs.readFileSync(__dirname + '/dir/asset1.txt'));
+console.log(fs.readFileSync(getDirAsset('asset2.txt')));
+console.log(fs.readdirSync(__dirname + '/dir'));
 
 function getDirAsset (name) {
     return __dirname + '/dir/' + name;

--- a/test/unit/dirname-emit-dedupe/output-coverage.js
+++ b/test/unit/dirname-emit-dedupe/output-coverage.js
@@ -91,8 +91,9 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 const fs = __webpack_require__(1);
-console.log(fs.readdirSync(__webpack_require__.ab + "asset1.txt"));
-console.log(fs.readdirSync(getDirAsset('asset2')));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset1.txt"));
+console.log(fs.readFileSync(getDirAsset('asset2.txt')));
+console.log(fs.readdirSync(__webpack_require__.ab + "dir"));
 
 function getDirAsset (name) {
     return __webpack_require__.ab + "dir/" + name;

--- a/test/unit/dirname-emit-dedupe/output.js
+++ b/test/unit/dirname-emit-dedupe/output.js
@@ -91,8 +91,9 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 const fs = __webpack_require__(1);
-console.log(fs.readdirSync(__webpack_require__.ab + "asset1.txt"));
-console.log(fs.readdirSync(getDirAsset('asset2')));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset1.txt"));
+console.log(fs.readFileSync(getDirAsset('asset2.txt')));
+console.log(fs.readdirSync(__webpack_require__.ab + "dir"));
 
 function getDirAsset (name) {
     return __webpack_require__.ab + "dir/" + name;


### PR DESCRIPTION
Exact dir emissions are still linked to their original path, so this handles that case as well.