### PR TITLE
fix: scoped version of node-pre-gyp unrecognized

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -207,6 +207,9 @@ const staticModules = Object.assign(Object.create(null), {
   'node-pre-gyp': pregyp,
   'node-pre-gyp/lib/pre-binding': pregyp,
   'node-pre-gyp/lib/pre-binding.js': pregyp,
+  '@mapbox/node-pre-gyp': pregyp,
+  '@mapbox/node-pre-gyp/lib/pre-binding': pregyp,
+  '@mapbox/node-pre-gyp/lib/pre-binding.js': pregyp,
   'node-gyp-build': {
     default: NODE_GYP_BUILD
   },


### PR DESCRIPTION
Hello,

As stated on https://www.npmjs.com/package/node-pre-gyp, `node-pre-gyp` has moved to `@mapbox/node-pre-gyp`. This is breaking relocation of some native modules such as `bcrypt: 5.0.1` so I have added the new scoped package to the list.
