### PR TITLE
fix: add release.config.js to configure main

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "branches": ["main"]
+}


### PR DESCRIPTION
This config is necessary since `semantic-release` doesn't detect the main branch for some reason.

- Docs: [Configuration File](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration-file)
- Related to https://github.com/semantic-release/semantic-release/issues/1581