### PR TITLE
feat: update acorn and add private fields support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   ],
   "devDependencies": {
     "@vercel/ncc": "^0.25.1",
-    "acorn": "^8.1.0",
+    "acorn": "^8.3.0",
     "acorn-class-fields": "^1.0.0",
+    "acorn-private-class-elements": "^1.0.0",
     "acorn-static-class-features": "^1.0.0",
     "bindings": "^1.4.0",
     "codecov": "^3.6.5",

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -23,6 +23,7 @@ const { pathToFileURL, fileURLToPath } = require('url');
 acorn = acorn.Parser.extend(
   require("acorn-class-fields"),
   require("acorn-static-class-features"),
+  require("acorn-private-class-elements")
 );
 
 const extensions = ['.js', '.json', '.node'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,6 +1199,11 @@ acorn@^8.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.1.tgz#0d36af126fb6755095879c1dc6fd7edf7d60a5fb"
   integrity sha512-z716cpm5TX4uzOzILx8PavOE6C6DKshHDw1aQN52M/yNSqE9s5O8SMfyhCCfCJ3HmTL0NkVOi+8a/55T7YB3bg==
 
+acorn@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.3.0.tgz#1193f9b96c4e8232f00b11a9edff81b2c8b98b88"
+  integrity sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==
+
 after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"


### PR DESCRIPTION
This brings through the same updates from NFT adding support for private fields and eg numeric separators.