### PR TITLE
feat: esm output mode for asset relocator chunks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ Any `.node` files included will also support binary relocation.
         use: {
           loader: '@vercel/webpack-asset-relocator-loader',
           options: {
+            // optional, whether the bundle is an esm bundle (import.meta.url / import() instead of __dirname / require)
+            esm: false,
             // optional, base folder for asset emission (eg assets/name.ext)
             outputAssetBase: 'assets',
             // optional, restrict asset emissions to only the given folder.
@@ -99,7 +101,7 @@ webpack({
     {
       apply(compiler) {
         compiler.hooks.compilation.tap("webpack-asset-relocator-loader", compilation => {
-          relocateLoader.initAssetCache(compilation, outputAssetBase);
+          relocateLoader.initAssetCache(compilation, outputAssetBase, esm);
         });
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,6 @@ Any `.node` files included will also support binary relocation.
         use: {
           loader: '@vercel/webpack-asset-relocator-loader',
           options: {
-            // optional, whether the bundle is an esm bundle (import.meta.url / import() instead of __dirname / require)
-            esm: false,
             // optional, base folder for asset emission (eg assets/name.ext)
             outputAssetBase: 'assets',
             // optional, restrict asset emissions to only the given folder.
@@ -101,7 +99,7 @@ webpack({
     {
       apply(compiler) {
         compiler.hooks.compilation.tap("webpack-asset-relocator-loader", compilation => {
-          relocateLoader.initAssetCache(compilation, outputAssetBase, esm);
+          relocateLoader.initAssetCache(compilation, outputAssetBase);
         });
       }
     }

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -337,7 +337,7 @@ function injectPathHook (compilation, outputAssetBase) {
         if (relBase.length)
           relBase = '/' + relBase;
       }
-      return `${source}\nif (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${esm ? "new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\\/\\/\\/\\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
+      return `${source}\nif (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${esm ? "new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\\/\\/\\/\\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
     });
   }
 }

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -324,7 +324,8 @@ function generateWildcardRequire(dir, wildcardPath, wildcardParam, wildcardBlock
 }
 
 const hooked = new WeakSet();
-function injectPathHook (compilation, outputAssetBase, esm) {
+function injectPathHook (compilation, outputAssetBase) {
+  const esm = compilation.outputOptions.module;
   const { mainTemplate } = compilation;
   if (!hooked.has(mainTemplate)) {
     hooked.add(mainTemplate);
@@ -336,7 +337,7 @@ function injectPathHook (compilation, outputAssetBase, esm) {
         if (relBase.length)
           relBase = '/' + relBase;
       }
-      return `${source}\nif (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${esm ? "new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
+      return `${source}\nif (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${esm ? "new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\\/\\/\\/\\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
     });
   }
 }
@@ -351,7 +352,7 @@ module.exports = async function (content, map) {
   // injection to set __webpack_require__.ab
   const options = getOptions(this);
 
-  injectPathHook(this._compilation, options.outputAssetBase, options.esm);
+  injectPathHook(this._compilation, options.outputAssetBase);
 
   if (id.endsWith('.node')) {
     const assetState = getAssetState(options, this._compilation);
@@ -1344,8 +1345,8 @@ module.exports.getSymlinks = function (compilation) {
     return lastState.assetSymlinks;
 };
 
-module.exports.initAssetCache = module.exports.initAssetMetaCache = function (compilation, outputAssetBase, esm) {
-  injectPathHook(compilation, outputAssetBase, esm);
+module.exports.initAssetCache = module.exports.initAssetMetaCache = function (compilation, outputAssetBase) {
+  injectPathHook(compilation, outputAssetBase);
   const entryIds = getEntryIds(compilation);
   if (!entryIds)
     return;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,12 +10,14 @@ global._unit = true;
 const relocateLoader = require(__dirname + (global.coverage ? "/../src/asset-relocator" : "/../"));
 const plugins = [{
   apply(compiler) {
-    compiler.hooks.compilation.tap("relocate-loader", compilation => relocateLoader.initAssetCache(compilation));
+    compiler.hooks.compilation.tap("relocate-loader", compilation => relocateLoader.initAssetCache(compilation, null, true));
   }
 }];
 
 for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   it(`should generate correct output for ${unitTest}`, async () => {
+    if (!unitTest.startsWith('esm-'))
+      return;
     // simple error test
     let shouldError = false;
     if (unitTest.endsWith('-err'))
@@ -53,6 +55,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
           use: [{
             loader: __dirname + (global.coverage ? "/../src/asset-relocator" : "/../"),
             options: {
+              esm: unitTest.startsWith('esm-'),
               existingAssetNames: ['existing.txt'],
               filterAssetBase: path.resolve('test'),
               customEmit: unitTest.startsWith('custom-emit') ? path => {

--- a/test/unit/esm-dirname/input.js
+++ b/test/unit/esm-dirname/input.js
@@ -1,0 +1,2 @@
+const fs = require('fs');
+console.log(fs.readdirSync(__dirname));

--- a/test/unit/esm-dirname/output-coverage.js
+++ b/test/unit/esm-dirname/output-coverage.js
@@ -1,0 +1,52 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 747:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs");;
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:///w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+const fs = __webpack_require__(747);
+console.log(fs.readdirSync(__webpack_require__.ab + "esm-dirname"));
+
+})();
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/esm-dirname/output-coverage.js
+++ b/test/unit/esm-dirname/output-coverage.js
@@ -37,7 +37,7 @@ module.exports = require("fs");;
 /************************************************************************/
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/esm-dirname/output-coverage.js
+++ b/test/unit/esm-dirname/output-coverage.js
@@ -1,5 +1,4 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	var __webpack_modules__ = ({
+/******/ var __webpack_modules__ = ({
 
 /***/ 747:
 /***/ ((module) => {
@@ -9,36 +8,36 @@ module.exports = require("fs");;
 
 /***/ })
 
-/******/ 	});
+/******/ });
 /************************************************************************/
-/******/ 	// The module cache
-/******/ 	var __webpack_module_cache__ = {};
-/******/ 	
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/ 		// Check if module is in cache
-/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
-/******/ 		if (cachedModule !== undefined) {
-/******/ 			return cachedModule.exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = __webpack_module_cache__[moduleId] = {
-/******/ 			// no module.id needed
-/******/ 			// no module.loaded needed
-/******/ 			exports: {}
-/******/ 		};
-/******/ 	
-/******/ 		// Execute the module function
-/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-/******/ 	
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
+/******/ // The module cache
+/******/ var __webpack_module_cache__ = {};
+/******/ 
+/******/ // The require function
+/******/ function __webpack_require__(moduleId) {
+/******/ 	// Check if module is in cache
+/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 	if (cachedModule !== undefined) {
+/******/ 		return cachedModule.exports;
 /******/ 	}
-/******/ 	
+/******/ 	// Create a new module (and put it into the cache)
+/******/ 	var module = __webpack_module_cache__[moduleId] = {
+/******/ 		// no module.id needed
+/******/ 		// no module.loaded needed
+/******/ 		exports: {}
+/******/ 	};
+/******/ 
+/******/ 	// Execute the module function
+/******/ 	__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 
+/******/ 	// Return the exports of the module
+/******/ 	return module.exports;
+/******/ }
+/******/ 
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:///w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
@@ -46,7 +45,3 @@ const fs = __webpack_require__(747);
 console.log(fs.readdirSync(__webpack_require__.ab + "esm-dirname"));
 
 })();
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/esm-dirname/output.js
+++ b/test/unit/esm-dirname/output.js
@@ -1,0 +1,52 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 747:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs");;
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:///w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+const fs = __webpack_require__(747);
+console.log(fs.readdirSync(__webpack_require__.ab + "esm-dirname"));
+
+})();
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/esm-dirname/output.js
+++ b/test/unit/esm-dirname/output.js
@@ -37,7 +37,7 @@ module.exports = require("fs");;
 /************************************************************************/
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/esm-dirname/output.js
+++ b/test/unit/esm-dirname/output.js
@@ -1,5 +1,4 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	var __webpack_modules__ = ({
+/******/ var __webpack_modules__ = ({
 
 /***/ 747:
 /***/ ((module) => {
@@ -9,36 +8,36 @@ module.exports = require("fs");;
 
 /***/ })
 
-/******/ 	});
+/******/ });
 /************************************************************************/
-/******/ 	// The module cache
-/******/ 	var __webpack_module_cache__ = {};
-/******/ 	
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/ 		// Check if module is in cache
-/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
-/******/ 		if (cachedModule !== undefined) {
-/******/ 			return cachedModule.exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = __webpack_module_cache__[moduleId] = {
-/******/ 			// no module.id needed
-/******/ 			// no module.loaded needed
-/******/ 			exports: {}
-/******/ 		};
-/******/ 	
-/******/ 		// Execute the module function
-/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-/******/ 	
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
+/******/ // The module cache
+/******/ var __webpack_module_cache__ = {};
+/******/ 
+/******/ // The require function
+/******/ function __webpack_require__(moduleId) {
+/******/ 	// Check if module is in cache
+/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 	if (cachedModule !== undefined) {
+/******/ 		return cachedModule.exports;
 /******/ 	}
-/******/ 	
+/******/ 	// Create a new module (and put it into the cache)
+/******/ 	var module = __webpack_module_cache__[moduleId] = {
+/******/ 		// no module.id needed
+/******/ 		// no module.loaded needed
+/******/ 		exports: {}
+/******/ 	};
+/******/ 
+/******/ 	// Execute the module function
+/******/ 	__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 
+/******/ 	// Return the exports of the module
+/******/ 	return module.exports;
+/******/ }
+/******/ 
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:///w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('..', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
@@ -46,7 +45,3 @@ const fs = __webpack_require__(747);
 console.log(fs.readdirSync(__webpack_require__.ab + "esm-dirname"));
 
 })();
-
-module.exports = __webpack_exports__;
-/******/ })()
-;


### PR DESCRIPTION
This adds support for module chunk emission to handle the asset base as relative to `import.meta.url` instead of `__dirname`.