### PR TITLE
fix: correctly handle Windows path in emitAssetDirectory

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -517,7 +517,7 @@ module.exports = async function (content, map) {
           assetExpressions += " + " + code.substring(wildcard.start, wildcard.end);
       }
       if (curPattern.length) {
-        assetExpressions += " + \'" + JSON.stringify(curPattern).replace(/\\/g, '/').slice(1, -1) + "'";
+        assetExpressions += " + \'" + JSON.stringify(curPattern.replace(/\\/g, '/')).slice(1, -1) + "'";
       }
     }
     return "__webpack_require__.ab + " + JSON.stringify((name + firstPrefix).replace(/\\/g, '/')) + assetExpressions;


### PR DESCRIPTION
## Problem

On windows, one of the unit tests does not pass:


```
  ● should generate correct output for wildcard2

    expect(received).toBe(expected) // Object.is equality

    - Expected  - 1
    + Received  + 1

    @@ -42,11 +42,11 @@
      var __webpack_exports__ = {};
      // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
      (() => {
      const path = __webpack_require__(622);

    - fs.readFileSync(__webpack_require__.ab + "wildcard2/" + unknown + '/asset1.txt');
    + fs.readFileSync(__webpack_require__.ab + "wildcard2/" + unknown + '//asset1.txt');


      })();

      module.exports = __webpack_exports__;

      112 |       .replace(/\r/g, "");
      113 |     try {
    > 114 |       expect(actual).toBe(expected);
          |                      ^
      115 |     } catch (e) {
      116 |       // useful for updating fixtures
      117 |       fs.writeFileSync(`${testDir}/actual.js`, actual);

      at Object.toBe (test/index.test.js:114:22)
```

## Cause

`JSON.stringify` here escapes `\` into `\\`, which is then `.replace`ed with `//` instead of a single `/`.

https://github.com/vercel/webpack-asset-relocator-loader/blob/bbb3be9a135870703290d2c6c62c88be52fbdcf7/src/asset-relocator.js#L520

## Proposed Fix

Do `.replace` first and then `JSON.stringify` to avoid the extra `/`. No change is unit test is required.