### PR TITLE
chore: update ci to node@14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [12]
+        node: [14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
12.x went EOL on 2022-04-30