### PR TITLE
fix: Use computed node-gyp-build path

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -905,7 +905,7 @@ module.exports = async function (content, map) {
             break;
             // require('bindings')(...)
             case BINDINGS:
-              if (node.arguments.length) {
+              if (node.arguments.length > 0) {
                 const arg = computePureStaticValue(node.arguments[0], false).result;
                 if (arg && arg.value) {
                   let staticBindingsInstance = false;
@@ -934,7 +934,7 @@ module.exports = async function (content, map) {
               }
             break;
             case NODE_GYP_BUILD:
-              if (node.arguments.length) {
+              if (node.arguments.length > 0) {
                 const arg = computePureStaticValue(node.arguments[0], false).result;
                 if (arg && arg.value) {
                   transformed = true;
@@ -963,7 +963,7 @@ module.exports = async function (content, map) {
             break;
             // nbind.init(...) -> require('./resolved.node')
             case NBIND_INIT:
-              if (node.arguments.length) {
+              if (node.arguments.length > 0) {
                 const arg = computePureStaticValue(node.arguments[0], false).result;
                 if (arg && arg.value) {
                   const bindingInfo = nbind(arg.value);

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -934,19 +934,21 @@ module.exports = async function (content, map) {
               }
             break;
             case NODE_GYP_BUILD:
-              if (node.arguments.length === 1 && node.arguments[0].type === 'Identifier' &&
-                  node.arguments[0].name === '__dirname' && knownBindings.__dirname.shadowDepth === 0) {
-                transformed = true;
-                let resolved;
-                try {
-                  resolved = nodeGypBuild.path(dir);
-                }
-                catch (e) {}
-                if (resolved) {
-                  staticChildValue = { value: resolved };
-                  staticChildNode = node;
-                  emitStaticChildAsset(path);
-                  return backtrack(this, parent);
+              if (node.arguments.length) {
+                const arg = computePureStaticValue(node.arguments[0], false).result;
+                if (arg && arg.value) {
+                  transformed = true;
+                  let resolved;
+                  try {
+                    resolved = nodeGypBuild.path(arg.value);
+                  }
+                  catch (e) {}
+                  if (resolved) {
+                    staticChildValue = { value: resolved };
+                    staticChildNode = node;
+                    emitStaticChildAsset(path);
+                    return backtrack(this, parent);
+                  }
                 }
               }
             break;

--- a/test/unit/node-gyp-build-resolve/fake-binding/package.json
+++ b/test/unit/node-gyp-build-resolve/fake-binding/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-binding",
+  "version": "1.0.0",
+  "description": "Fake binding that contains just enough for node-gyp-build to be able to resolve it (the .node file is a dummy empty file and cannot actually be imported)"
+}

--- a/test/unit/node-gyp-build-resolve/fake-binding/src/index.js
+++ b/test/unit/node-gyp-build-resolve/fake-binding/src/index.js
@@ -1,0 +1,2 @@
+const path = require("path");
+require('node-gyp-build')(path.resolve(__dirname, ".."));

--- a/test/unit/node-gyp-build-resolve/input.js
+++ b/test/unit/node-gyp-build-resolve/input.js
@@ -1,0 +1,1 @@
+require('./fake-binding/src/index.js');

--- a/test/unit/node-gyp-build-resolve/output-coverage.js
+++ b/test/unit/node-gyp-build-resolve/output-coverage.js
@@ -1,0 +1,60 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 710:
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+
+const path = __webpack_require__(622);
+require(__webpack_require__.ab + "node.napi.node");
+
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");;
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+__webpack_require__(710);
+
+})();
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/node-gyp-build-resolve/output.js
+++ b/test/unit/node-gyp-build-resolve/output.js
@@ -1,0 +1,60 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 86:
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+
+const path = __webpack_require__(622);
+require(__webpack_require__.ab + "node.napi.node");
+
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");;
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+__webpack_require__(86);
+
+})();
+
+module.exports = __webpack_exports__;
+/******/ })()
+;


### PR DESCRIPTION
This is based on existing PR #168 by @MarshallOfSound

I rebased the original commits except for the one introducing the tests which I have rewritten

Instead of requiring an external library (ffi-napi), I created a dummy binding that node-pre-gyp can use as input with a predictable binding file path that won't depend on the platform.