### PR TITLE
fix: 1.7.3 to 1.7.4 regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 coverage
 test/**/dist
+test/unit/**/actual.js

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "ncc build src/asset-relocator.js -e resolve",
+    "build": "node ./scripts/build.js",
     "codecov": "codecov",
-    "test": "npm run build && jest",
+    "test": "yarn run build && jest",
     "test-pnp": "yarn pack -f test/yarn-pnp/assets-plugin-tarball.tgz && cd test/yarn-pnp && echo '' > yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn run build && yarn run test",
     "test-coverage": "jest --coverage --globals \"{\\\"coverage\\\":true}\" && codecov"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,28 @@
+const fs = require('fs')
+const path = require('path')
+const ncc = require('@vercel/ncc')
+
+const build = () => {
+  const entry = path.resolve(__dirname, '../src/asset-relocator.js')
+
+  ncc(entry, {
+    externals: ["resolve"],
+    minify: true
+  }).then(({ code }) => {
+    const distFile = path.resolve(__dirname, '../dist/index.js')
+
+    // replace all __nccwpck_require__ with __webpack_require__ caused by ncc
+    const newCode = code.replace(
+      /__nccwpck_require__/g,
+      '__webpack_require__'
+    )
+
+    fs.writeFileSync(distFile, newCode)
+  }).catch(err => {
+    console.error(err)
+
+    process.exit(1)
+  })
+}
+
+build()

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -342,12 +342,9 @@ function injectPathHook (compilation, outputAssetBase) {
     }
 
     generate() {
-      const requireBase = `${esm ? "new URL('', import.meta.url).pathname.slice(import.meta.url.match(/^file:\\/\\/\\/\\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(this.relBase + '/' + assetBase(outputAssetBase))}`
+      const requireBase = `${esm ? "new URL('', import.meta.url).pathname.slice(import.meta.url.match(/^file:\\/\\/\\/\\w:/) ? 1 : 0, -1)" : '__dirname'} + ${JSON.stringify(this.relBase + '/' + assetBase(outputAssetBase))}`;
 
-      return [
-        `if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${requireBase};`,
-        `if (typeof __nccwpck_require__ !== 'undefined') { __nccwpck_require__.ab = ${requireBase} } else if (typeof __webpack_require__ !== 'undefined') { __nccwpck_require__ = __webpack_require__ };`
-      ].join('\n');
+      return `if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = ${requireBase};`
     }
   }
 
@@ -364,7 +361,11 @@ function injectPathHook (compilation, outputAssetBase) {
         }
       }
 
-      compilation.addRuntimeModule(chunk, new AssetRelocatorLoaderRuntimeModule({ relBase }));
+      try {
+        compilation.addRuntimeModule(chunk, new AssetRelocatorLoaderRuntimeModule({ relBase }));
+      } catch (error) {
+        console.error(error);
+      }
 
       return true;
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -102,7 +102,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
     try {
       code = mfs.readFileSync("/index.js", "utf8");
     }
-    catch (e) {
+    catch (err) {
       throw new Error(stats.toString());
     }
 
@@ -112,10 +112,10 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
       .replace(/\r/g, "");
     try {
       expect(actual).toBe(expected);
-    } catch (e) {
+    } catch (err) {
       // useful for updating fixtures
       fs.writeFileSync(`${testDir}/actual.js`, actual);
-      throw e;
+      throw err;
     }
 
     // very simple asset validation in unit tests

--- a/test/unit/amd-disable/output-coverage.js
+++ b/test/unit/amd-disable/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 if (typeof define === 'function' && define.amd)
   define(function (require) {

--- a/test/unit/amd-disable/output.js
+++ b/test/unit/amd-disable/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 if (typeof define === 'function' && define.amd)
   define(function (require) {

--- a/test/unit/array-emission/output-coverage.js
+++ b/test/unit/array-emission/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/array-emission/output.js
+++ b/test/unit/array-emission/output.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -49,8 +50,8 @@ var __webpack_exports__ = {};
 const fs = __webpack_require__(147);
 
 const REPORT_JAVASCRIPT = [
-  fs.readFileSync(__nccwpck_require__.ab + "util.js", 'utf8'),
-  fs.readFileSync(__nccwpck_require__.ab + "dom.js", 'utf8'),
+  fs.readFileSync(__webpack_require__.ab + "util.js", 'utf8'),
+  fs.readFileSync(__webpack_require__.ab + "dom.js", 'utf8'),
 ].join(';\n');
 
 })();

--- a/test/unit/array-holes/output-coverage.js
+++ b/test/unit/array-holes/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 var a = [1,,2];
 

--- a/test/unit/array-holes/output.js
+++ b/test/unit/array-holes/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 var a = [1,,2];
 

--- a/test/unit/asset-conditional/output-coverage.js
+++ b/test/unit/asset-conditional/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-conditional/output.js
+++ b/test/unit/asset-conditional/output.js
@@ -36,16 +36,17 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const path = __webpack_require__(17);
-let moduleJsPath = isHarmony ? __nccwpck_require__.ab + "asset1.txt" : __nccwpck_require__.ab + "asset2.txt";
+let moduleJsPath = isHarmony ? __webpack_require__.ab + "asset1.txt" : __webpack_require__.ab + "asset2.txt";
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/asset-fs-array-expr/output-coverage.js
+++ b/test/unit/asset-fs-array-expr/output-coverage.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-array-expr/output.js
+++ b/test/unit/asset-fs-array-expr/output.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -55,7 +56,7 @@ var __webpack_exports__ = {};
 const { spawn } = __webpack_require__(81);
 const { join } = __webpack_require__(17);
 
-const child = spawn(gifsicle, ['--colors', '256', __nccwpck_require__.ab + "asset1.txt"]);
+const child = spawn(gifsicle, ['--colors', '256', __webpack_require__.ab + "asset1.txt"]);
 
 })();
 

--- a/test/unit/asset-fs-existing-asset-name/output-coverage.js
+++ b/test/unit/asset-fs-existing-asset-name/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-existing-asset-name/output.js
+++ b/test/unit/asset-fs-existing-asset-name/output.js
@@ -36,16 +36,17 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "existing1.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "existing1.txt"));
 
 })();
 

--- a/test/unit/asset-fs-inline-assign/output-coverage.js
+++ b/test/unit/asset-fs-inline-assign/output-coverage.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-assign/output.js
+++ b/test/unit/asset-fs-inline-assign/output.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -55,11 +56,11 @@ var __webpack_exports__ = {};
 const fs = __webpack_require__(147);
 const { join } = __webpack_require__(17);
 
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 
 (function () {
   var join = () => 'nope';
-  console.log(fs.readFileSync(join(__nccwpck_require__.ab + "asset-fs-inline-assign", 'asset.txt'), 'utf8'));
+  console.log(fs.readFileSync(join(__webpack_require__.ab + "asset-fs-inline-assign", 'asset.txt'), 'utf8'));
 })();
 })();
 

--- a/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc-es-2/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -62,7 +86,7 @@ const external_path_namespaceObject = require("path");
 
 
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc-es-3/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -62,7 +86,7 @@ const external_path_namespaceObject = require("path");
 
 
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc-es-4/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -64,7 +88,7 @@ const external_path_namespaceObject = require("path");
 
 const join = external_path_namespaceObject.join;
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/test/unit/asset-fs-inline-path-enc-es-5/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-5/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc-es-5/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-5/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -62,7 +86,7 @@ const external_path_namespaceObject = require("path");
 
 
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc-es/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -62,7 +86,7 @@ const external_path_namespaceObject = require("path");
 
 
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/test/unit/asset-fs-inline-path-enc/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc/output-coverage.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-enc/output.js
+++ b/test/unit/asset-fs-inline-path-enc/output.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -54,7 +55,7 @@ var __webpack_exports__ = {};
 (() => {
 const fs = __webpack_require__(147);
 const { join } = __webpack_require__(17);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/asset-fs-inline-path-shadow/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-shadow/output-coverage.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -55,11 +56,11 @@ var __webpack_exports__ = {};
 const fs = __webpack_require__(147);
 const { join } = __webpack_require__(17);
 
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt", 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt", 'utf8'));
 
 (function () {
   var join = () => 'nope';
-  console.log(fs.readFileSync(join(__nccwpck_require__.ab + "asset-fs-inline-path-shadow", 'asset.txt'), 'utf8'));
+  console.log(fs.readFileSync(join(__webpack_require__.ab + "asset-fs-inline-path-shadow", 'asset.txt'), 'utf8'));
 })();
 })();
 

--- a/test/unit/asset-fs-inline-tpl/output-coverage.js
+++ b/test/unit/asset-fs-inline-tpl/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inline-tpl/output.js
+++ b/test/unit/asset-fs-inline-tpl/output.js
@@ -36,16 +36,17 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt"));
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/asset-fs-inlining-multi/output-coverage.js
+++ b/test/unit/asset-fs-inlining-multi/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inlining-multi/output.js
+++ b/test/unit/asset-fs-inlining-multi/output.js
@@ -36,17 +36,18 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt"));
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset1.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset1.txt"));
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/asset-fs-inlining/output-coverage.js
+++ b/test/unit/asset-fs-inlining/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-inlining/output.js
+++ b/test/unit/asset-fs-inlining/output.js
@@ -36,16 +36,17 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset.txt"));
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/asset-fs-logical/output-coverage.js
+++ b/test/unit/asset-fs-logical/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-fs-logical/output.js
+++ b/test/unit/asset-fs-logical/output.js
@@ -36,16 +36,17 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(unknown ? __nccwpck_require__.ab + "asset1.txt" : __nccwpck_require__.ab + "asset2.txt"));
+console.log(fs.readFileSync(unknown ? __webpack_require__.ab + "asset1.txt" : __webpack_require__.ab + "asset2.txt"));
 
 })();
 

--- a/test/unit/asset-node-require/output-coverage.js
+++ b/test/unit/asset-node-require/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 179:
+/***/ 534:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 module.exports = require(__webpack_require__.ab + "mock.node")
@@ -35,15 +35,16 @@ module.exports = require(__webpack_require__.ab + "mock.node")
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-__webpack_require__(179);
+__webpack_require__(534);
 
 })();
 

--- a/test/unit/asset-node-require/output.js
+++ b/test/unit/asset-node-require/output.js
@@ -2,9 +2,9 @@
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 534:
-/***/ ((module) => {
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-module.exports = require(__nccwpck_require__.ab + "mock.node")
+module.exports = require(__webpack_require__.ab + "mock.node")
 
 /***/ })
 
@@ -35,9 +35,10 @@ module.exports = require(__nccwpck_require__.ab + "mock.node")
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-package-json/output-coverage.js
+++ b/test/unit/asset-package-json/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/asset-package-json/output.js
+++ b/test/unit/asset-package-json/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -47,7 +48,7 @@ var __webpack_exports__ = {};
 const path = __webpack_require__(17);
 
 var binding_path =
-    binary.find(__nccwpck_require__.ab + "package.json");
+    binary.find(__webpack_require__.ab + "package.json");
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/bindings-failure/output-coverage.js
+++ b/test/unit/bindings-failure/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 718:
+/***/ 22:
 /***/ ((module, exports, __webpack_require__) => {
 
 /**
@@ -10,7 +10,7 @@
 
 var fs = __webpack_require__(147),
   path = __webpack_require__(17),
-  fileURLToPath = __webpack_require__(518),
+  fileURLToPath = __webpack_require__(519),
   join = path.join,
   dirname = path.dirname,
   exists =
@@ -229,7 +229,7 @@ exports.getRoot = function getRoot(file) {
 
 /***/ }),
 
-/***/ 518:
+/***/ 519:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 
@@ -345,15 +345,16 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-__webpack_require__(718)('not-found');
+__webpack_require__(22)('not-found');
 
 })();
 

--- a/test/unit/bindings-failure/output.js
+++ b/test/unit/bindings-failure/output.js
@@ -345,9 +345,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/browserify-minify/output-coverage.js
+++ b/test/unit/browserify-minify/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 683:
+/***/ 358:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -10,7 +10,7 @@ module.exports = 'dep';
 
 /***/ }),
 
-/***/ 377:
+/***/ 303:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 ! function (e) {
@@ -44,7 +44,7 @@ module.exports = 'dep';
     }, {
       './dep.js': void 0
     }]
-  }, {"./dep.js": { exports: __webpack_require__(683) }}, [1])(1)
+  }, {"./dep.js": { exports: __webpack_require__(358) }}, [1])(1)
 });
 
 
@@ -77,16 +77,17 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(377);
+/******/ 	var __webpack_exports__ = __webpack_require__(303);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/browserify-minify/output.js
+++ b/test/unit/browserify-minify/output.js
@@ -77,9 +77,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/browserify-uglify/output-coverage.js
+++ b/test/unit/browserify-uglify/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 909:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 !function(f) {
@@ -886,16 +886,17 @@ module.exports = require("util");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(909);
+/******/ 	var __webpack_exports__ = __webpack_require__(188);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/browserify-uglify/output.js
+++ b/test/unit/browserify-uglify/output.js
@@ -886,9 +886,10 @@ module.exports = require("util");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/browserify/output-coverage.js
+++ b/test/unit/browserify/output-coverage.js
@@ -1,27 +1,27 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 84:
+/***/ 25:
 /***/ ((module) => {
 
 module.exports = 'dep1';
 
 /***/ }),
 
-/***/ 7:
+/***/ 776:
 /***/ ((module) => {
 
 module.exports = 'dep2';
 
 /***/ }),
 
-/***/ 869:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 (function(f){if(true){module.exports=f()}else { var g; }})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c=require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u=require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
   module.exports = [require("./dep1"), require("./dep2")];
-},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(84) },
-  "./dep2": { exports: __webpack_require__(7) }},[1])(1)
+},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(25) },
+  "./dep2": { exports: __webpack_require__(776) }},[1])(1)
 });
 
 /***/ })
@@ -53,16 +53,17 @@ module.exports = 'dep2';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(869);
+/******/ 	var __webpack_exports__ = __webpack_require__(382);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/browserify/output.js
+++ b/test/unit/browserify/output.js
@@ -53,9 +53,10 @@ module.exports = 'dep2';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/custom-emit-require-multiassign/output-coverage.js
+++ b/test/unit/custom-emit-require-multiassign/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 73:
+/***/ 402:
 /***/ ((module) => {
 
 module.exports = 'a';
@@ -9,7 +9,7 @@ module.exports = 'a';
 
 /***/ }),
 
-/***/ 785:
+/***/ 714:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 var m = './a.js';
@@ -17,7 +17,7 @@ var m = './a.js';
 if (global.something)
   m = './b.js';
 
-module.exports = __webpack_require__(73);
+module.exports = __webpack_require__(402);
 
 
 /***/ })
@@ -49,16 +49,17 @@ module.exports = __webpack_require__(73);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module used 'module' so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(785);
+/******/ 	var __webpack_exports__ = __webpack_require__(714);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/custom-emit-require-multiassign/output.js
+++ b/test/unit/custom-emit-require-multiassign/output.js
@@ -49,9 +49,10 @@ module.exports = __webpack_require__(402);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/custom-emit-require/output-coverage.js
+++ b/test/unit/custom-emit-require/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/custom-emit-require/output.js
+++ b/test/unit/custom-emit-require/output.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/custom-emit/output-coverage.js
+++ b/test/unit/custom-emit/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/custom-emit/output.js
+++ b/test/unit/custom-emit/output.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/dirname-emit-dedupe/output-coverage.js
+++ b/test/unit/dirname-emit-dedupe/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/dirname-emit-dedupe/output.js
+++ b/test/unit/dirname-emit-dedupe/output.js
@@ -36,21 +36,22 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readFileSync(__nccwpck_require__.ab + "asset1.txt"));
+console.log(fs.readFileSync(__webpack_require__.ab + "asset1.txt"));
 console.log(fs.readFileSync(getDirAsset('asset2.txt')));
-console.log(fs.readdirSync(__nccwpck_require__.ab + "dir"));
+console.log(fs.readdirSync(__webpack_require__.ab + "dir"));
 
 function getDirAsset (name) {
-    return __nccwpck_require__.ab + "dir/" + name;
+    return __webpack_require__.ab + "dir/" + name;
 }
 
 })();

--- a/test/unit/dirname-emit/output-coverage.js
+++ b/test/unit/dirname-emit/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/dirname-emit/output.js
+++ b/test/unit/dirname-emit/output.js
@@ -36,16 +36,17 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readdirSync(__nccwpck_require__.ab + "dirname-emit"));
+console.log(fs.readdirSync(__webpack_require__.ab + "dirname-emit"));
 
 })();
 

--- a/test/unit/dirname-len/output-coverage.js
+++ b/test/unit/dirname-len/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 console.log(function (a, b) {
   return b.filter(function (c) {

--- a/test/unit/dirname-len/output.js
+++ b/test/unit/dirname-len/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 console.log(function (a, b) {
   return b.filter(function (c) {

--- a/test/unit/esm-dirname/output-coverage.js
+++ b/test/unit/esm-dirname/output-coverage.js
@@ -35,9 +35,10 @@ module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs");
 /******/ }
 /******/ 
 /************************************************************************/
-/******/ /* webpack/runtime/compat */
-/******/ 
-/******/ if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ /* webpack/runtime/asset-relocator-loader */
+/******/ (() => {
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ })();
 /******/ 
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/esm-dirname/output.js
+++ b/test/unit/esm-dirname/output.js
@@ -35,15 +35,16 @@ module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs");
 /******/ }
 /******/ 
 /************************************************************************/
-/******/ /* webpack/runtime/compat */
-/******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ /* webpack/runtime/asset-relocator-loader */
+/******/ (() => {
+/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = new URL('', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ })();
 /******/ 
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __webpack_require__(147);
-console.log(fs.readdirSync(__nccwpck_require__.ab + "esm-dirname"));
+console.log(fs.readdirSync(__webpack_require__.ab + "esm-dirname"));
 
 })();

--- a/test/unit/esm/output-coverage.js
+++ b/test/unit/esm/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 730:
+/***/ 738:
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
@@ -39,6 +39,11 @@ var hello = 'world';
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -56,17 +61,13 @@ var hello = 'world';
 /******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 ;
 
-(__webpack_require__(730)/* .hello */ .o);
+(__webpack_require__(738)/* .hello */ .o);
 
 })();
 

--- a/test/unit/esm/output.js
+++ b/test/unit/esm/output.js
@@ -39,6 +39,11 @@ var hello = 'world';
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -55,10 +60,6 @@ var hello = 'world';
 /******/ 	(() => {
 /******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/express-template-engine/output-coverage.js
+++ b/test/unit/express-template-engine/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 347:
+/***/ 357:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 const express = __webpack_require__(146);
@@ -65,16 +65,17 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(347);
+/******/ 	var __webpack_exports__ = __webpack_require__(357);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/express-template-engine/output.js
+++ b/test/unit/express-template-engine/output.js
@@ -65,9 +65,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/express-template/output-coverage.js
+++ b/test/unit/express-template/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 498:
+/***/ 965:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 const express = __webpack_require__(146);
@@ -72,16 +72,17 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(498);
+/******/ 	var __webpack_exports__ = __webpack_require__(965);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/express-template/output.js
+++ b/test/unit/express-template/output.js
@@ -72,9 +72,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/ffmpeg-installer/output-coverage.js
+++ b/test/unit/ffmpeg-installer/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 605:
+/***/ 221:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 "use strict";
@@ -100,15 +100,16 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-let { path } = __webpack_require__(605);
+let { path } = __webpack_require__(221);
 console.log(path);
 })();
 

--- a/test/unit/ffmpeg-installer/output.js
+++ b/test/unit/ffmpeg-installer/output.js
@@ -20,10 +20,10 @@ var packageName = '@ffmpeg-installer/' + platform;
 var binary = os.platform() === 'win32' ? 'ffmpeg.exe' : 'ffmpeg.exe';
 
 var npm3Path = path.resolve(__dirname, '..', platform);
-var npm2Path = __nccwpck_require__.ab + "ffmpeg-installer";
+var npm2Path = __webpack_require__.ab + "ffmpeg-installer";
 
 var npm3Binary = path.join(npm3Path, binary);
-var npm2Binary = __nccwpck_require__.ab + "ffmpeg.exe";
+var npm2Binary = __webpack_require__.ab + "ffmpeg.exe";
 
 var npm3Package = path.join(npm3Path, 'package.json');
 var npm2Package = path.join(npm2Path, 'package.json');
@@ -32,8 +32,8 @@ var ffmpegPath, packageJson;
 
 if (verifyFile(npm3Binary)) {
     ffmpegPath = npm3Binary;
-} else if (verifyFile(__nccwpck_require__.ab + "ffmpeg.exe")) {
-    ffmpegPath = __nccwpck_require__.ab + "ffmpeg.exe";
+} else if (verifyFile(__webpack_require__.ab + "ffmpeg.exe")) {
+    ffmpegPath = __webpack_require__.ab + "ffmpeg.exe";
 } else {
     throw 'Could not find ffmpeg executable, tried "' + npm3Binary + '" and "' + npm2Binary + '"';
 }
@@ -42,7 +42,7 @@ var version = packageJson.ffmpeg || packageJson.version;
 var url = packageJson.homepage;
 
 module.exports = {
-    path: __nccwpck_require__.ab + "ffmpeg.exe",
+    path: __webpack_require__.ab + "ffmpeg.exe",
     version: version,
     url: url
 };
@@ -100,9 +100,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/filter-asset-base/output-coverage.js
+++ b/test/unit/filter-asset-base/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/filter-asset-base/output.js
+++ b/test/unit/filter-asset-base/output.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/fs-emission/output-coverage.js
+++ b/test/unit/fs-emission/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/fs-emission/output.js
+++ b/test/unit/fs-emission/output.js
@@ -36,9 +36,10 @@ module.exports = require("fs");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -48,11 +49,11 @@ const fs = __webpack_require__(147);
 
 fs.readFile('./asset1.txt')
 
-fs.readFile(__nccwpck_require__.ab + "asset2.txt")
+fs.readFile(__webpack_require__.ab + "asset2.txt")
 
-const _basePath = __nccwpck_require__.ab + "fs-emission";
+const _basePath = __webpack_require__.ab + "fs-emission";
 const asset3 = 'asset3.txt';
-fs.readFileSync(__nccwpck_require__.ab + "asset3.txt", 'utf8');
+fs.readFileSync(__webpack_require__.ab + "asset3.txt", 'utf8');
 
 })();
 

--- a/test/unit/google-gax/output-coverage.js
+++ b/test/unit/google-gax/output-coverage.js
@@ -26,9 +26,10 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/google-gax/output.js
+++ b/test/unit/google-gax/output.js
@@ -1,11 +1,39 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-const googleProtoFilesDir = __nccwpck_require__.ab + "google-gax";
+const googleProtoFilesDir = __webpack_require__.ab + "google-gax";
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/google-gax2/output-coverage.js
+++ b/test/unit/google-gax2/output-coverage.js
@@ -26,9 +26,10 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/google-gax2/output.js
+++ b/test/unit/google-gax2/output.js
@@ -1,11 +1,39 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-var googleProtoFilesDir = __nccwpck_require__.ab + "google-gax2";
+var googleProtoFilesDir = __webpack_require__.ab + "google-gax2";
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/import-meta-bad-url/output-coverage.js
+++ b/test/unit/import-meta-bad-url/output-coverage.js
@@ -15,10 +15,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG

--- a/test/unit/import-meta-bad-url/output.js
+++ b/test/unit/import-meta-bad-url/output.js
@@ -15,10 +15,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG

--- a/test/unit/import-meta-tpl-cnd/output-coverage.js
+++ b/test/unit/import-meta-tpl-cnd/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
@@ -37,10 +42,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/import-meta-tpl-cnd/output.js
+++ b/test/unit/import-meta-tpl-cnd/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
@@ -14,10 +42,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -32,7 +56,7 @@ const external_url_namespaceObject = require("url");
 
 
 
-console.log((0,external_fs_namespaceObject.readFileSync)((0,external_url_namespaceObject.fileURLToPath)(unknown ? __nccwpck_require__.ab + "asset1.txt" : __nccwpck_require__.ab + "asset2.txt")).toString());
+console.log((0,external_fs_namespaceObject.readFileSync)((0,external_url_namespaceObject.fileURLToPath)(unknown ? __webpack_require__.ab + "asset1.txt" : __webpack_require__.ab + "asset2.txt")).toString());
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/import-meta-url/output-coverage.js
+++ b/test/unit/import-meta-url/output-coverage.js
@@ -27,6 +27,11 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -66,10 +71,6 @@
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/import-meta-url/output.js
+++ b/test/unit/import-meta-url/output.js
@@ -1,9 +1,37 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __webpack_require__ = {};
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -44,10 +72,6 @@
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
@@ -58,7 +82,7 @@ const external_fs_namespaceObject = require("fs");
 var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ./test/unit/import-meta-url/input.js
 
-console.log(external_fs_default().readFileSync(__nccwpck_require__.ab + "asset.txt"));
+console.log(external_fs_default().readFileSync(__webpack_require__.ab + "asset.txt"));
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/jsonc-parse-wrapper/output-coverage.js
+++ b/test/unit/jsonc-parse-wrapper/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 809:
+/***/ 849:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -9,7 +9,7 @@ module.exports = 'dep';
 
 /***/ }),
 
-/***/ 642:
+/***/ 327:
 /***/ ((module, exports, __webpack_require__) => {
 
 (function (factory) {
@@ -21,7 +21,7 @@ module.exports = 'dep';
      define(["require", "exports", "./impl/format", "./impl/edit", "./impl/scanner", "./impl/parser"], factory);
  }
 })(function () {
-  __webpack_require__(809);
+  __webpack_require__(849);
 });
 
 /***/ })
@@ -53,16 +53,17 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(642);
+/******/ 	var __webpack_exports__ = __webpack_require__(327);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/jsonc-parse-wrapper/output.js
+++ b/test/unit/jsonc-parse-wrapper/output.js
@@ -53,9 +53,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/main-equal/output-coverage.js
+++ b/test/unit/main-equal/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 428:
+/***/ 599:
 /***/ (() => {
 
 // this is a dep main check, so it is known to be false
@@ -37,15 +37,16 @@ console.log(false);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-__webpack_require__(428);
+__webpack_require__(599);
 // this is the entry main check, so it becomes an outer main check
 console.log(require.main === require.cache[eval('__filename')]);
 

--- a/test/unit/main-equal/output.js
+++ b/test/unit/main-equal/output.js
@@ -37,9 +37,10 @@ console.log(false);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/module-require/output-coverage.js
+++ b/test/unit/module-require/output-coverage.js
@@ -1,14 +1,14 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 222:
+/***/ 543:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 function x (module) {
 }
 
 exports.asdf = 'asdf';
-console.log(__webpack_require__(222));
+console.log(__webpack_require__(543));
 
 if (true)
   console.log("yes");
@@ -43,16 +43,17 @@ if (true)
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(222);
+/******/ 	var __webpack_exports__ = __webpack_require__(543);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/module-require/output.js
+++ b/test/unit/module-require/output.js
@@ -43,9 +43,10 @@ if (true)
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/mongoose/output-coverage.js
+++ b/test/unit/mongoose/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 393:
+/***/ 569:
 /***/ ((module) => {
 
 module.exports = 'connection';
@@ -36,9 +36,10 @@ module.exports = 'connection';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -46,7 +47,7 @@ var __webpack_exports__ = {};
 (() => {
 const driver = global.MONGOOSE_DRIVER_PATH || './dir';
 
-const Connection = __webpack_require__(393);
+const Connection = __webpack_require__(569);
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/mongoose/output.js
+++ b/test/unit/mongoose/output.js
@@ -36,9 +36,10 @@ module.exports = 'connection';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/node-gyp-build-resolve/output-coverage.js
+++ b/test/unit/node-gyp-build-resolve/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 710:
+/***/ 86:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
 const path = __webpack_require__(17);
@@ -45,15 +45,16 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-__webpack_require__(710);
+__webpack_require__(86);
 
 })();
 

--- a/test/unit/node-gyp-build-resolve/output.js
+++ b/test/unit/node-gyp-build-resolve/output.js
@@ -5,7 +5,7 @@
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
 const path = __webpack_require__(17);
-require(__nccwpck_require__.ab + "node.napi.node");
+require(__webpack_require__.ab + "node.napi.node");
 
 
 /***/ }),
@@ -45,9 +45,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/non-analyzable-requires/output-coverage.js
+++ b/test/unit/non-analyzable-requires/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 246:
+/***/ 517:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -36,16 +36,17 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 // analyzable:
-__webpack_require__(246);
+__webpack_require__(517);
 
 // non-analyzable:
 var s = {

--- a/test/unit/non-analyzable-requires/output.js
+++ b/test/unit/non-analyzable-requires/output.js
@@ -36,9 +36,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/null-destructure/output-coverage.js
+++ b/test/unit/null-destructure/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 Object.define
 const a = null;

--- a/test/unit/null-destructure/output.js
+++ b/test/unit/null-destructure/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 Object.define
 const a = null;

--- a/test/unit/oracledb/output-coverage.js
+++ b/test/unit/oracledb/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 745:
+/***/ 71:
 /***/ ((module) => {
 
 module.exports = 'oracledb';
@@ -35,9 +35,10 @@ module.exports = 'oracledb';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -51,7 +52,7 @@ var binaryLocations = [
 
 for (var i = 0; i < binaryLocations.length; i++) {
   try {
-    oracledbCLib = __webpack_require__(745);
+    oracledbCLib = __webpack_require__(71);
     break;
   } catch(err) {
     if (err.code !== 'MODULE_NOT_FOUND' || i == binaryLocations.length - 1) {

--- a/test/unit/oracledb/output.js
+++ b/test/unit/oracledb/output.js
@@ -35,9 +35,10 @@ module.exports = 'oracledb';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -58,7 +59,7 @@ for (var i = 0; i < binaryLocations.length; i++) {
       var nodeInfo;
       if (err.code === 'MODULE_NOT_FOUND') {
         // none of the three binaries could be found
-        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __nccwpck_require__.ab + "oracledb/" + x).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
+        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __webpack_require__.ab + "oracledb/" + x).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
       } else {
         nodeInfo = `\n  Node.js require('oracledb') error was:\n  ${err.message}\n  ${nodbUtil.getInstallHelp()}\n`;
       }

--- a/test/unit/path-sep/output-coverage.js
+++ b/test/unit/path-sep/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/path-sep/output.js
+++ b/test/unit/path-sep/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -48,7 +49,7 @@ const { sep } = __webpack_require__(17);
 
 const X = (/* unused pure expression or super */ null && (sep));
 
-fs.readFileSync(__nccwpck_require__.ab + "asset.txt");
+fs.readFileSync(__webpack_require__.ab + "asset.txt");
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/pkginfo/output-coverage.js
+++ b/test/unit/pkginfo/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 943:
+/***/ 537:
 /***/ ((module) => {
 
 Object.assign(module.exports, {"version":"x.y.z","dependencies":{}});
@@ -36,16 +36,11 @@ Object.assign(module.exports, {"version":"x.y.z","dependencies":{}});
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(943);
+/******/ 	var __webpack_exports__ = __webpack_require__(537);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/pkginfo/output.js
+++ b/test/unit/pkginfo/output.js
@@ -36,11 +36,6 @@ Object.assign(module.exports, {"version":"x.y.z","dependencies":{}});
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports

--- a/test/unit/process-env/output-coverage.js
+++ b/test/unit/process-env/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 462:
+/***/ 568:
 /***/ (() => {
 
 console.log('a');
@@ -36,15 +36,16 @@ console.log('a');
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-__webpack_require__(462);
+__webpack_require__(568);
 
 })();
 

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -36,9 +36,10 @@ console.log('a');
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/protobuf-loop/output-coverage.js
+++ b/test/unit/protobuf-loop/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/protobuf-loop/output.js
+++ b/test/unit/protobuf-loop/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -51,10 +52,10 @@ const path = __webpack_require__(17);
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __nccwpck_require__.ab + "assets";
+    var sourceDir = __webpack_require__.ab + "assets";
     for (var _i = 0, wellKnownProtos_1 = wellKnownProtos; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos_1[_i];
-        var file = __nccwpck_require__.ab + "assets/" + proto + '.txt';
+        var file = __webpack_require__.ab + "assets/" + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);

--- a/test/unit/protobuf-loop2/output-coverage.js
+++ b/test/unit/protobuf-loop2/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/protobuf-loop2/output.js
+++ b/test/unit/protobuf-loop2/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -51,11 +52,11 @@ const path = __webpack_require__(17);
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __nccwpck_require__.ab + "assets";
+    var sourceDir = __webpack_require__.ab + "assets";
     var _i;
     for (_i = 0; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos[_i];
-        var file = __nccwpck_require__.ab + "assets/" + proto + '.txt';
+        var file = __webpack_require__.ab + "assets/" + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);

--- a/test/unit/require-call/output-coverage.js
+++ b/test/unit/require-call/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 require(call());
 

--- a/test/unit/require-call/output.js
+++ b/test/unit/require-call/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 require(call());
 

--- a/test/unit/require-check/output-coverage.js
+++ b/test/unit/require-check/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 const requireFunc =  true ? eval("require") : 0;
 const foo = requireFunc(moduleName);

--- a/test/unit/require-check/output.js
+++ b/test/unit/require-check/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 const requireFunc =  true ? eval("require") : 0;
 const foo = requireFunc(moduleName);

--- a/test/unit/require-dirname-tpl/output-coverage.js
+++ b/test/unit/require-dirname-tpl/output-coverage.js
@@ -1,10 +1,10 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 633:
+/***/ 684:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
-__webpack_require__(633);
+__webpack_require__(684);
 
 /***/ })
 
@@ -35,16 +35,17 @@ __webpack_require__(633);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(633);
+/******/ 	var __webpack_exports__ = __webpack_require__(684);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/require-dirname-tpl/output.js
+++ b/test/unit/require-dirname-tpl/output.js
@@ -35,9 +35,10 @@ __webpack_require__(684);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/require-dynamic-fallback/output-coverage.js
+++ b/test/unit/require-dynamic-fallback/output-coverage.js
@@ -1,10 +1,10 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 997:
+/***/ 253:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
-__webpack_require__(997);
+__webpack_require__(253);
 
 
 /***/ })
@@ -36,16 +36,17 @@ __webpack_require__(997);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(997);
+/******/ 	var __webpack_exports__ = __webpack_require__(253);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/require-dynamic-fallback/output.js
+++ b/test/unit/require-dynamic-fallback/output.js
@@ -36,9 +36,10 @@ __webpack_require__(253);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/require-empty/output-coverage.js
+++ b/test/unit/require-empty/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 try {
   typescriptPath = '';

--- a/test/unit/require-empty/output.js
+++ b/test/unit/require-empty/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 try {
   typescriptPath = '';

--- a/test/unit/require-esm/output-coverage.js
+++ b/test/unit/require-esm/output-coverage.js
@@ -36,6 +36,11 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -63,10 +68,6 @@ module.exports = require("path");
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/require-esm/output.js
+++ b/test/unit/require-esm/output.js
@@ -36,6 +36,11 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -63,10 +68,6 @@ module.exports = require("path");
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/require-main/output-coverage.js
+++ b/test/unit/require-main/output-coverage.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 console.log(require.main.filename);
 module.exports = __webpack_exports__;

--- a/test/unit/require-main/output.js
+++ b/test/unit/require-main/output.js
@@ -1,9 +1,4 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
-/************************************************************************/
 var __webpack_exports__ = {};
 console.log(require.main.filename);
 module.exports = __webpack_exports__;

--- a/test/unit/require-multiassign/output-coverage.js
+++ b/test/unit/require-multiassign/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 984:
+/***/ 553:
 /***/ ((module) => {
 
 module.exports = 'b';
@@ -9,7 +9,7 @@ module.exports = 'b';
 
 /***/ }),
 
-/***/ 282:
+/***/ 818:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 var m = './a.js';
@@ -17,7 +17,7 @@ var m = './a.js';
 if (global.something)
   m = './b.js';
 
-module.exports = __webpack_require__(984);
+module.exports = __webpack_require__(553);
 
 
 /***/ })
@@ -49,16 +49,17 @@ module.exports = __webpack_require__(984);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module used 'module' so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(282);
+/******/ 	var __webpack_exports__ = __webpack_require__(818);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/require-multiassign/output.js
+++ b/test/unit/require-multiassign/output.js
@@ -49,9 +49,10 @@ module.exports = __webpack_require__(553);
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/require-resolve-like/output-coverage.js
+++ b/test/unit/require-resolve-like/output-coverage.js
@@ -1,11 +1,11 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 261:
+/***/ 880:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
 // this should be a self-require not an asset!
-__webpack_require__(261)
+__webpack_require__(880)
 
 /***/ })
 
@@ -36,16 +36,17 @@ __webpack_require__(261)
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(261);
+/******/ 	var __webpack_exports__ = __webpack_require__(880);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/require-resolve-like/output.js
+++ b/test/unit/require-resolve-like/output.js
@@ -36,9 +36,10 @@ __webpack_require__(880)
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/require-resolve/output-coverage.js
+++ b/test/unit/require-resolve/output-coverage.js
@@ -26,9 +26,10 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/require-resolve/output.js
+++ b/test/unit/require-resolve/output.js
@@ -1,18 +1,46 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-const asset1 = __nccwpck_require__.ab + "asset1.txt";
+const asset1 = __webpack_require__.ab + "asset1.txt";
 
 function loader () {}
-loader(__nccwpck_require__.ab + "asset2.txt");
+loader(__webpack_require__.ab + "asset2.txt");
 
-unknown(__nccwpck_require__.ab + "asset1.txt");
+unknown(__webpack_require__.ab + "asset1.txt");
 
-const thing = asdf(__nccwpck_require__.ab + "asset3.txt");
+const thing = asdf(__webpack_require__.ab + "asset3.txt");
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/test/unit/require-wrapper/output-coverage.js
+++ b/test/unit/require-wrapper/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 896:
+/***/ 946:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -36,9 +36,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -56,7 +57,7 @@ const reaction = name => {
 
 const reactions = {
 	repository: {
-		publicized: reaction$$mod(__webpack_require__(896), './dep')
+		publicized: reaction$$mod(__webpack_require__(946), './dep')
 	}
 };
 

--- a/test/unit/require-wrapper/output.js
+++ b/test/unit/require-wrapper/output.js
@@ -36,9 +36,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/require-wrapper2/output-coverage.js
+++ b/test/unit/require-wrapper2/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 880:
+/***/ 127:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -36,9 +36,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -56,7 +57,7 @@ function reaction (name) {
 
 const reactions = {
 	repository: {
-		publicized: reaction$$mod(__webpack_require__(880), './dep')
+		publicized: reaction$$mod(__webpack_require__(127), './dep')
 	}
 };
 

--- a/test/unit/require-wrapper2/output.js
+++ b/test/unit/require-wrapper2/output.js
@@ -36,9 +36,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/require-wrapper3/output-coverage.js
+++ b/test/unit/require-wrapper3/output-coverage.js
@@ -1,15 +1,13 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	var __webpack_modules__ = ({
-
-/***/ 372:
+/******/ 	var __webpack_modules__ = ([
+/* 0 */
 /***/ ((module) => {
 
 module.exports = 'dep';
 
 
 /***/ })
-
-/******/ 	});
+/******/ 	]);
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
@@ -36,9 +34,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -56,7 +55,7 @@ const reaction = (name) => {
 
 const reactions = {
 	repository: {
-		publicized: reaction$$mod(__webpack_require__(372), './dep')
+		publicized: reaction$$mod(__webpack_require__(0), './dep')
 	}
 };
 

--- a/test/unit/require-wrapper3/output.js
+++ b/test/unit/require-wrapper3/output.js
@@ -34,9 +34,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/resolve-from/output-coverage.js
+++ b/test/unit/resolve-from/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 937:
+/***/ 419:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 "use strict";
@@ -44,11 +44,11 @@ module.exports.silent = (fromDir, moduleId) => resolveFrom(fromDir, moduleId, tr
 
 /***/ }),
 
-/***/ 564:
+/***/ 629:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
-var resolveFrom = __webpack_require__(937);
-var x = /*require.resolve*/( 564);
+var resolveFrom = __webpack_require__(419);
+var x = /*require.resolve*/( 629);
 require(x);
 
 
@@ -97,16 +97,17 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(564);
+/******/ 	var __webpack_exports__ = __webpack_require__(629);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/resolve-from/output.js
+++ b/test/unit/resolve-from/output.js
@@ -97,9 +97,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/return-emission/output-coverage.js
+++ b/test/unit/return-emission/output-coverage.js
@@ -26,9 +26,10 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/return-emission/output.js
+++ b/test/unit/return-emission/output.js
@@ -1,12 +1,40 @@
 /******/ (() => { // webpackBootstrap
-/******/ 	/* webpack/runtime/compat */
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 function f () {
-  return __nccwpck_require__.ab + "return-emission";
+  return __webpack_require__.ab + "return-emission";
 }
 
 module.exports = __webpack_exports__;

--- a/test/unit/socket.io/output-coverage.js
+++ b/test/unit/socket.io/output-coverage.js
@@ -27,9 +27,10 @@
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/socket.io/output.js
+++ b/test/unit/socket.io/output.js
@@ -1,8 +1,36 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	/* webpack/runtime/compat */
+/******/ 	var __webpack_modules__ = ({});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -19,7 +47,7 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var filepath = path.resolve(__nccwpck_require__.ab + "socket.io", './../../', file);
+    var filepath = path.resolve(__webpack_require__.ab + "socket.io", './../../', file);
     if (exists(filepath)) {
       return filepath;
     }

--- a/test/unit/tla/output-coverage.js
+++ b/test/unit/tla/output-coverage.js
@@ -2,7 +2,7 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 430:
+/***/ 34:
 /***/ ((module, __webpack_exports__, __webpack_require__) => {
 
 __webpack_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
@@ -143,16 +143,12 @@ __webpack_async_result__();
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module used 'module' so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(430);
+/******/ 	var __webpack_exports__ = __webpack_require__(34);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/tla/output.js
+++ b/test/unit/tla/output.js
@@ -143,10 +143,6 @@ __webpack_async_result__();
 /******/ 		};
 /******/ 	})();
 /******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup

--- a/test/unit/webpack-wrapper/output-coverage.js
+++ b/test/unit/webpack-wrapper/output-coverage.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/webpack-wrapper/output.js
+++ b/test/unit/webpack-wrapper/output.js
@@ -44,9 +44,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -115,7 +116,7 @@ var __webpack_exports__ = {};
   function(e, t, r) {
     const n = __webpack_require__(147),
       o = __webpack_require__(17);
-    console.log(n.readFileSync(__nccwpck_require__.ab + "asset.txt"));
+    console.log(n.readFileSync(__webpack_require__.ab + "asset.txt"));
   }
 ]);
 })();

--- a/test/unit/when-wrapper/output-coverage.js
+++ b/test/unit/when-wrapper/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 606:
+/***/ 847:
 /***/ ((module) => {
 
 module.exports = 'dep';
@@ -9,13 +9,13 @@ module.exports = 'dep';
 
 /***/ }),
 
-/***/ 749:
+/***/ 292:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 (function (define) {
   'use strict';
   define(function () {
-    __webpack_require__(606);
+    __webpack_require__(847);
   });
 })
 (typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); })
@@ -50,16 +50,17 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __webpack_require__(749);
+/******/ 	var __webpack_exports__ = __webpack_require__(292);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/test/unit/when-wrapper/output.js
+++ b/test/unit/when-wrapper/output.js
@@ -50,9 +50,10 @@ module.exports = 'dep';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/test/unit/wildcard-require/output-coverage.js
+++ b/test/unit/wildcard-require/output-coverage.js
@@ -1,14 +1,14 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 995:
+/***/ 284:
 /***/ ((module) => {
 
 module.exports = 'module1';
 
 /***/ }),
 
-/***/ 137:
+/***/ 583:
 /***/ ((module) => {
 
 module.exports = 'module2';
@@ -16,7 +16,7 @@ module.exports = 'module2';
 
 /***/ }),
 
-/***/ 495:
+/***/ 997:
 /***/ ((module) => {
 
 module.exports = 'module3';
@@ -51,18 +51,19 @@ module.exports = 'module3';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 function __ncc_wildcard$0 (arg) {
-  if (arg === "1.js" || arg === "1") return __webpack_require__(995);
-  else if (arg === "2.js" || arg === "2") return __webpack_require__(137);
-  else if (arg === "3.js" || arg === "3") return __webpack_require__(495);
+  if (arg === "1.js" || arg === "1") return __webpack_require__(284);
+  else if (arg === "2.js" || arg === "2") return __webpack_require__(583);
+  else if (arg === "3.js" || arg === "3") return __webpack_require__(997);
 }
 const num = Math.ceil(Math.random() * 3, 0);
 

--- a/test/unit/wildcard-require/output.js
+++ b/test/unit/wildcard-require/output.js
@@ -51,9 +51,10 @@ module.exports = 'module3';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/wildcard-require2/output-coverage.js
+++ b/test/unit/wildcard-require2/output-coverage.js
@@ -1,14 +1,14 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 52:
+/***/ 805:
 /***/ ((module) => {
 
 module.exports = 'module1';
 
 /***/ }),
 
-/***/ 139:
+/***/ 387:
 /***/ ((module) => {
 
 module.exports = 'module2';
@@ -16,7 +16,7 @@ module.exports = 'module2';
 
 /***/ }),
 
-/***/ 446:
+/***/ 455:
 /***/ ((module) => {
 
 module.exports = 'module3';
@@ -51,18 +51,19 @@ module.exports = 'module3';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 function __ncc_wildcard$0 (arg) {
-  if (arg === "path1") return __webpack_require__(52);
-  else if (arg === "path2") return __webpack_require__(139);
-  else if (arg === "path3") return __webpack_require__(446);
+  if (arg === "path1") return __webpack_require__(805);
+  else if (arg === "path2") return __webpack_require__(387);
+  else if (arg === "path3") return __webpack_require__(455);
 }
 const num = Math.ceil(Math.random() * 3, 0);
 

--- a/test/unit/wildcard-require2/output.js
+++ b/test/unit/wildcard-require2/output.js
@@ -51,9 +51,10 @@ module.exports = 'module3';
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/wildcard/output-coverage.js
+++ b/test/unit/wildcard/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/wildcard/output.js
+++ b/test/unit/wildcard/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -46,8 +47,8 @@ var __webpack_exports__ = {};
 (() => {
 const path = __webpack_require__(17);
 
-fs.readFileSync(__nccwpck_require__.ab + "assets/" + unknown + '.txt');
-fs.readFileSync(__nccwpck_require__.ab + "assets/" + unknown.join('/') + '.txt');
+fs.readFileSync(__webpack_require__.ab + "assets/" + unknown + '.txt');
+fs.readFileSync(__webpack_require__.ab + "assets/" + unknown.join('/') + '.txt');
 
 })();
 

--- a/test/unit/wildcard2/output-coverage.js
+++ b/test/unit/wildcard2/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/wildcard2/output.js
+++ b/test/unit/wildcard2/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
@@ -46,7 +47,7 @@ var __webpack_exports__ = {};
 (() => {
 const path = __webpack_require__(17);
 
-fs.readFileSync(__nccwpck_require__.ab + "wildcard2/" + unknown + '/asset1.txt');
+fs.readFileSync(__webpack_require__.ab + "wildcard2/" + unknown + '/asset1.txt');
 
 
 })();

--- a/test/unit/wildcard3/output-coverage.js
+++ b/test/unit/wildcard3/output-coverage.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};

--- a/test/unit/wildcard3/output.js
+++ b/test/unit/wildcard3/output.js
@@ -36,9 +36,10 @@ module.exports = require("path");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	/* webpack/runtime/asset-relocator-loader */
+/******/ 	(() => {
+/******/ 		if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/";
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};


### PR DESCRIPTION
Remove the use of the deprecated Webpack MainTemplate. If `__nccwpck__` is not present, fall back to `__webpack_require__`. It fixes the [regression from 1.7.3 to 1.7.4](https://github.com/vercel/webpack-asset-relocator-loader/issues/188) and it also allows for compatibility with [rspack](https://github.com/web-infra-dev/rspack).