### PR TITLE
fix: support the packaging format of sharp v0.34.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         run: node --version
       - name: Install Dependencies
         run: yarn install
+      - name: Install Test Dependencies
+        run: yarn install
+        working-directory: test/project-chunking
       - name: Run Tests
         run: yarn test
       # - name: Run yarn pnp tests

--- a/test/project-chunking/expected.js
+++ b/test/project-chunking/expected.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 
 expect(stats.compilation.errors.length).toBe(0);
+expect(stats.compilation.chunks.length).toBe(8);
 
 // check relative asset references worked out
 expect(fs.readFileSync(__dirname + "/dist/main.js").toString()).toContain(`ab+"asset`);
@@ -11,3 +12,7 @@ expect(fs.readFileSync(__dirname + "/dist/chunks/42.js").toString()).toContain(`
 
 expect(fs.readFileSync(__dirname + "/dist/chunks/sharp-chunk.js").toString()).toContain(`ab+"sharp`);
 expect(fs.readFileSync(__dirname + "/dist/chunks/sharp32-chunk.js").toString()).toContain(`ab+"build`);
+
+const assets = Object.keys(stats.compilation.assets);
+expect(assets.some(asset => /lib\/sharp-.+\.node/.exec(asset))).toBeTruthy();
+expect(assets.some(asset => /Release\/sharp-.+\.node/.exec(asset))).toBeTruthy();

--- a/test/project-chunking/expected.js
+++ b/test/project-chunking/expected.js
@@ -1,10 +1,13 @@
 
 const fs = require('fs');
 
-expect([26, 27]).toContain(output.length);
+// expect([26, 27]).toContain(output.length);
 
 // check relative asset references worked out
 expect(fs.readFileSync(__dirname + "/dist/modules/main.js").toString()).toContain(`ab+"asset`);
 expect(fs.readFileSync(__dirname + "/dist/modules/chunk.js").toString()).toContain(`ab+"asset`);
 expect(fs.readFileSync(__dirname + "/dist/modules/chunks/758.js").toString()).toContain(`ab+"asset`);
 expect(fs.readFileSync(__dirname + "/dist/modules/chunks/151.js").toString()).toContain(`ab+"asset`);
+
+expect(fs.readFileSync(__dirname + "/dist/modules/chunks/sharp-chunk.js").toString()).toContain(`ab+"sharp`);
+expect(fs.readFileSync(__dirname + "/dist/modules/chunks/sharp32-chunk.js").toString()).toContain(`ab+"build`);

--- a/test/project-chunking/expected.js
+++ b/test/project-chunking/expected.js
@@ -1,7 +1,7 @@
 
 const fs = require('fs');
 
-// expect([26, 27]).toContain(output.length);
+expect(stats.compilation.errors.length).toBe(0);
 
 // check relative asset references worked out
 expect(fs.readFileSync(__dirname + "/dist/main.js").toString()).toContain(`ab+"asset`);

--- a/test/project-chunking/expected.js
+++ b/test/project-chunking/expected.js
@@ -4,10 +4,10 @@ const fs = require('fs');
 // expect([26, 27]).toContain(output.length);
 
 // check relative asset references worked out
-expect(fs.readFileSync(__dirname + "/dist/modules/main.js").toString()).toContain(`ab+"asset`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunk.js").toString()).toContain(`ab+"asset`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunks/758.js").toString()).toContain(`ab+"asset`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunks/151.js").toString()).toContain(`ab+"asset`);
+expect(fs.readFileSync(__dirname + "/dist/main.js").toString()).toContain(`ab+"asset`);
+expect(fs.readFileSync(__dirname + "/dist/chunk.js").toString()).toContain(`ab+"asset`);
+expect(fs.readFileSync(__dirname + "/dist/chunks/541.js").toString()).toContain(`ab+"asset`);
+expect(fs.readFileSync(__dirname + "/dist/chunks/42.js").toString()).toContain(`ab+"asset`);
 
-expect(fs.readFileSync(__dirname + "/dist/modules/chunks/sharp-chunk.js").toString()).toContain(`ab+"sharp`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunks/sharp32-chunk.js").toString()).toContain(`ab+"build`);
+expect(fs.readFileSync(__dirname + "/dist/chunks/sharp-chunk.js").toString()).toContain(`ab+"sharp`);
+expect(fs.readFileSync(__dirname + "/dist/chunks/sharp32-chunk.js").toString()).toContain(`ab+"build`);

--- a/test/project-chunking/main.js
+++ b/test/project-chunking/main.js
@@ -4,5 +4,3 @@ console.log(fs.readFileSync(__dirname + '/asset1/asset.txt').toString());
 
 require.ensure('./chunk2', function () {});
 require.ensure('./chunk3', function () {});
-require.ensure('./packages/sharp', function () {}, 'sharp');
-require.ensure('./packages/sharp32', function () {}, 'sharp32');

--- a/test/project-chunking/main.js
+++ b/test/project-chunking/main.js
@@ -4,3 +4,5 @@ console.log(fs.readFileSync(__dirname + '/asset1/asset.txt').toString());
 
 require.ensure('./chunk2', function () {});
 require.ensure('./chunk3', function () {});
+require.ensure('./packages/sharp', function () {}, 'sharp');
+require.ensure('./packages/sharp32', function () {}, 'sharp32');

--- a/test/project-chunking/package.json
+++ b/test/project-chunking/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "project-chunking",
+  "devDependencies": {
+    "sharp": "0.34.2",
+    "sharp32": "npm:sharp@0.32.6"
+  }
+}

--- a/test/project-chunking/packages/sharp.js
+++ b/test/project-chunking/packages/sharp.js
@@ -4,4 +4,8 @@ const roundedCorners = Buffer.from(
   '<svg><rect x="0" y="0" width="200" height="200" rx="50" ry="50"/></svg>'
 );
 
-sharp(roundedCorners).resize(200, 200).png().toBuffer();
+sharp(roundedCorners)
+  .resize(200, 200)
+  .png()
+  .toBuffer()
+  .then((buf) => console.log('sharp', buf));

--- a/test/project-chunking/packages/sharp.js
+++ b/test/project-chunking/packages/sharp.js
@@ -1,0 +1,7 @@
+const sharp = require('sharp');
+
+const roundedCorners = Buffer.from(
+  '<svg><rect x="0" y="0" width="200" height="200" rx="50" ry="50"/></svg>'
+);
+
+sharp(roundedCorners).resize(200, 200).png().toBuffer();

--- a/test/project-chunking/packages/sharp32.js
+++ b/test/project-chunking/packages/sharp32.js
@@ -4,4 +4,8 @@ const roundedCorners = Buffer.from(
   '<svg><rect x="0" y="0" width="200" height="200" rx="50" ry="50"/></svg>'
 );
 
-sharp(roundedCorners).resize(200, 200).png().toBuffer();
+sharp(roundedCorners)
+  .resize(200, 200)
+  .png()
+  .toBuffer()
+  .then((buf) => console.log('sharp32', buf));

--- a/test/project-chunking/packages/sharp32.js
+++ b/test/project-chunking/packages/sharp32.js
@@ -1,0 +1,7 @@
+const sharp = require('sharp32');
+
+const roundedCorners = Buffer.from(
+  '<svg><rect x="0" y="0" width="200" height="200" rx="50" ry="50"/></svg>'
+);
+
+sharp(roundedCorners).resize(200, 200).png().toBuffer();

--- a/test/project-chunking/webpack.config.js
+++ b/test/project-chunking/webpack.config.js
@@ -14,11 +14,25 @@ module.exports = {
   externals: ['fs'],
   module: {
     rules: [{
-      test: /\.m?js$/,
+      test: /\.(m?js|node)$/,
       parser: { amd: false },
       use: {
         loader: __dirname + '/../../src/asset-relocator.js'
       }
     }]
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        sharp: {
+          test: /[\\/]node_modules[\\/]sharp[\\/]/,
+          name: 'sharp-chunk',
+        },
+        sharp32: {
+          test: /[\\/]node_modules[\\/]sharp32[\\/]/,
+          name: 'sharp32-chunk',
+        }
+      }
+    }
   }
 };

--- a/test/project-chunking/webpack.config.js
+++ b/test/project-chunking/webpack.config.js
@@ -3,21 +3,25 @@ module.exports = {
   mode: 'production',
   entry: {
     main: './main.js',
-    chunk: './chunk.js'
+    chunk: './chunk.js',
+    sharp: './packages/sharp.js',
+    sharp32: './packages/sharp32.js'
   },
   output: {
     clean: true,
-    filename: 'modules/[name].js',
-    chunkFilename: 'modules/chunks/[name].js',
+    filename: '[name].js',
+    chunkFilename: 'chunks/[name].js',
     path: __dirname + '/dist'
   },
-  externals: ['fs'],
   module: {
     rules: [{
       test: /\.(m?js|node)$/,
       parser: { amd: false },
       use: {
-        loader: __dirname + '/../../src/asset-relocator.js'
+        loader: __dirname + '/../../src/asset-relocator.js',
+        options: {
+          outputAssetBase: 'assets'
+        }
       }
     }]
   },
@@ -26,11 +30,13 @@ module.exports = {
       cacheGroups: {
         sharp: {
           test: /[\\/]node_modules[\\/]sharp[\\/]/,
-          name: 'sharp-chunk',
+          name: 'chunks/sharp-chunk',
+          chunks: 'all',
         },
         sharp32: {
           test: /[\\/]node_modules[\\/]sharp32[\\/]/,
-          name: 'sharp32-chunk',
+          name: 'chunks/sharp32-chunk',
+          chunks: 'all',
         }
       }
     }


### PR DESCRIPTION
The idea is stolen from [nft](https://github.com/vercel/nft/blob/main/src/utils/special-cases.ts#L151), where we introspect package.json to retrieve optional dependencies containing the native addon and relocate them. Following that, I patched the [third item](https://github.com/lovell/sharp/blob/v0.34.2/lib/sharp.js#L16) within the path list, which will be used to load the addon file in the subsequent lines.

Since the prebuilt binaries are available on all platforms I could name, we may ignore the WASM builds. I've added integration tests requiring actual packages, but haven't updated the CI workflow yet, as it would cause longer CI times. The tests include sharp v0.34.2 and v0.32.6 to ensure the new mechanism doesn't affect the existing workflow. I've also run the scripts on both Windows and Linux (x64), and they worked as expected.

Another caveat is on the loading of libvips. On Windows, the dynamic libraries are included in a single package. While for Linux and Mac, they are divided into two packages. From a [quick search](https://github.com/search?q=repo%3Alovell%2Fsharp+%40img%2Fsharp-libvips&type=code), it seemed that they are only needed to build the binding.  Currently, they are copied, but nothing in the source is changed to load them.

```
// windows
sharp
└─ @img/sharp-win32-x64

// linux
├─ @img/sharp-libvips-linux-x64
├─ @img/sharp-libvips-linuxmusl-x64
├─ @img/sharp-linux-x64
└─ @img/sharp-linuxmusl-x64

// mac
├─ @img/sharp-darwin-arm64
└─ @img/sharp-libvips-darwin-arm64
```

Fixes: https://github.com/vercel/ncc/issues/1153