### PR TITLE
chore(readme): remove broken links to ci

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,5 @@
 # Asset Relocator Loader for Webpack
 
-[![Build Status](https://circleci.com/gh/vercel/webpack-asset-relocator-loader.svg?&style=shield)](https://circleci.com/gh/vercel/workflows/webpack-asset-relocator-loader)
-[![codecov](https://codecov.io/gh/vercel/webpack-asset-relocator-loader/branch/main/graph/badge.svg)](https://codecov.io/gh/vercel/webpack-asset-relocator-loader)
-
 Asset relocation loader used in ncc for performing Node.js builds while emitting and relocating any asset references.
 
 ## Usage


### PR DESCRIPTION
We haven't used circleci or codecov for years so we can remove these links from the readme.