### PR TITLE
fix(static-eval): skip evaluation when BigInt values are involved

### DIFF
--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -1,4 +1,4 @@
-module.exports = function (ast, vars = {}, computeBranches = true) {
+﻿module.exports = function (ast, vars = {}, computeBranches = true) {
   const state = {
     computeBranches,
     sawIdentifier: false,
@@ -55,6 +55,11 @@ const visitors = {
     let r = walk(node.right);
 
     if (!l && !r) return;
+
+    // Guard against BigInt mixing — mixing BigInt with other types in arithmetic
+    // throws TypeError at runtime, so skip static evaluation when BigInt is involved.
+    if (l && 'value' in l && typeof l.value === 'bigint') return;
+    if (r && 'value' in r && typeof r.value === 'bigint') return;
 
     if (!l) {
       // UNKNOWN + 'str' -> wildcard string value
@@ -251,6 +256,9 @@ const visitors = {
   Literal (node) {
     return { value: node.value };
   },
+  BigIntLiteral (node) {
+    return { value: node.value };
+  },
   MemberExpression (node, walk) {
     const obj = walk(node.object);
     // do not allow access to methods on Function 
@@ -421,6 +429,8 @@ const visitors = {
   UnaryExpression (node, walk) {
     const val = walk(node.argument);
     if (!val)
+      return;
+    if ('value' in val && typeof val.value === 'bigint')
       return;
     if ('value' in val && 'wildcards' in val === false) {
       if (node.operator === '+') return { value: +val.value };


### PR DESCRIPTION
## Summary

Fixes vercel/ncc#1307 — `TypeError: Cannot mix BigInt and other types` when ncc compiles projects using BigInt.

## Problem

When ncc compiles a project that depends on packages using BigInt (e.g. `dd-trace@5.87.0`), the static evaluator in `webpack-asset-relocator-loader` encounters BigInt literal values. The evaluator's `BinaryExpression` and `UnaryExpression` visitors perform arithmetic operations on resolved values, but JavaScript throws `TypeError: Cannot mix BigInt and other types, use explicit conversions` when mixing BigInt with Number operands.

## Fix

- Added a `BigIntLiteral` AST visitor to properly handle BigInt literal nodes (ESTree/Babel-style AST)
- In `BinaryExpression`: bail out of static evaluation when either operand resolves to a BigInt value, avoiding mixed-type arithmetic errors
- In `UnaryExpression`: bail out when the argument is a BigInt value, since operators like `+` and `~` are invalid on BigInt

When evaluation is skipped, the expression remains in the output as-is and is handled correctly at runtime.

## Test plan

- [x] BigIntLiteral nodes return BigInt values correctly
- [x] BinaryExpression with BigInt + Number skips evaluation (no TypeError)
- [x] BinaryExpression with BigInt > Number skips evaluation
- [x] UnaryExpression +BigInt skips evaluation
- [x] Normal Number + Number still evaluated correctly
- [x] String concatenation still works