### PR TITLE
fix: don't crash on statically-evaluated expressions that throw (BigInt mixing)

### DIFF
--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -78,73 +78,82 @@ const visitors = {
     if ('test' in l && 'test' in r)
       return;
 
-    if ('test' in l) {
-      r = r.value;
-      if (op === '==') return { test: l.test, then: l.then == r, else: l.else == r };
-      if (op === '===') return { test: l.test, then: l.then === r, else: l.else === r };
-      if (op === '!=') return { test: l.test, then: l.then != r, else: l.else != r };
-      if (op === '!==') return { test: l.test, then: l.then !== r, else: l.else !== r };
-      if (op === '+') return { test: l.test, then: l.then + r, else: l.else + r };
-      if (op === '-') return { test: l.test, then: l.then - r, else: l.else - r };
-      if (op === '*') return { test: l.test, then: l.then * r, else: l.else * r };
-      if (op === '/') return { test: l.test, then: l.then / r, else: l.else / r };
-      if (op === '%') return { test: l.test, then: l.then % r, else: l.else % r };
-      if (op === '<') return { test: l.test, then: l.then < r, else: l.else < r };
-      if (op === '<=') return { test: l.test, then: l.then <= r, else: l.else <= r };
-      if (op === '>') return { test: l.test, then: l.then > r, else: l.else > r };
-      if (op === '>=') return { test: l.test, then: l.then >= r, else: l.else >= r };
-      if (op === '|') return { test: l.test, then: l.then | r, else: l.else | r };
-      if (op === '&') return { test: l.test, then: l.then & r, else: l.else & r };
-      if (op === '^') return { test: l.test, then: l.then ^ r, else: l.else ^ r };
-      if (op === '&&') return { test: l.test, then: l.then && r, else: l.else && r };
-      if (op === '||') return { test: l.test, then: l.then || r, else: l.else || r };
-    }
-    else if ('test' in r) {
-      l = l.value;
-      if (op === '==') return { test: r.test, then: l == r.then, else: l == r.else };
-      if (op === '===') return { test: r.test, then: l === r.then, else: l === r.else };
-      if (op === '!=') return { test: r.test, then: l != r.then, else: l != r.else };
-      if (op === '!==') return { test: r.test, then: l !== r.then, else: l !== r.else };
-      if (op === '+') return { test: r.test, then: l + r.then, else: l + r.else };
-      if (op === '-') return { test: r.test, then: l - r.then, else: l - r.else };
-      if (op === '*') return { test: r.test, then: l * r.then, else: l * r.else };
-      if (op === '/') return { test: r.test, then: l / r.then, else: l / r.else };
-      if (op === '%') return { test: r.test, then: l % r.then, else: l % r.else };
-      if (op === '<') return { test: r.test, then: l < r.then, else: l < r.else };
-      if (op === '<=') return { test: r.test, then: l <= r.then, else: l <= r.else };
-      if (op === '>') return { test: r.test, then: l > r.then, else: l > r.else };
-      if (op === '>=') return { test: r.test, then: l >= r.then, else: l >= r.else };
-      if (op === '|') return { test: r.test, then: l | r.then, else: l | r.else };
-      if (op === '&') return { test: r.test, then: l & r.then, else: l & r.else };
-      if (op === '^') return { test: r.test, then: l ^ r.then, else: l ^ r.else };
-      if (op === '&&') return { test: r.test, then: l && r.then, else: l && r.else };
-      if (op === '||') return { test: r.test, then: l || r.then, else: l || r.else };
-    }
-    else {
-      if (op === '==') return { value: l.value == r.value };
-      if (op === '===') return { value: l.value === r.value };
-      if (op === '!=') return { value: l.value != r.value };
-      if (op === '!==') return { value: l.value !== r.value };
-      if (op === '+') {
-        const val = { value: l.value + r.value };
-        if (l.wildcards || r.wildcards)
-          val.wildcards = [...l.wildcards || [], ...r.wildcards || []];
-        return val;
+    // Evaluation can throw for known values, e.g. mixing a BigInt
+    // operand with another type ("Cannot mix BigInt and other types").
+    // Any such error just means the expression is not statically
+    // computable.
+    try {
+      if ('test' in l) {
+        r = r.value;
+        if (op === '==') return { test: l.test, then: l.then == r, else: l.else == r };
+        if (op === '===') return { test: l.test, then: l.then === r, else: l.else === r };
+        if (op === '!=') return { test: l.test, then: l.then != r, else: l.else != r };
+        if (op === '!==') return { test: l.test, then: l.then !== r, else: l.else !== r };
+        if (op === '+') return { test: l.test, then: l.then + r, else: l.else + r };
+        if (op === '-') return { test: l.test, then: l.then - r, else: l.else - r };
+        if (op === '*') return { test: l.test, then: l.then * r, else: l.else * r };
+        if (op === '/') return { test: l.test, then: l.then / r, else: l.else / r };
+        if (op === '%') return { test: l.test, then: l.then % r, else: l.else % r };
+        if (op === '<') return { test: l.test, then: l.then < r, else: l.else < r };
+        if (op === '<=') return { test: l.test, then: l.then <= r, else: l.else <= r };
+        if (op === '>') return { test: l.test, then: l.then > r, else: l.else > r };
+        if (op === '>=') return { test: l.test, then: l.then >= r, else: l.else >= r };
+        if (op === '|') return { test: l.test, then: l.then | r, else: l.else | r };
+        if (op === '&') return { test: l.test, then: l.then & r, else: l.else & r };
+        if (op === '^') return { test: l.test, then: l.then ^ r, else: l.else ^ r };
+        if (op === '&&') return { test: l.test, then: l.then && r, else: l.else && r };
+        if (op === '||') return { test: l.test, then: l.then || r, else: l.else || r };
       }
-      if (op === '-') return { value: l.value - r.value };
-      if (op === '*') return { value: l.value * r.value };
-      if (op === '/') return { value: l.value / r.value };
-      if (op === '%') return { value: l.value % r.value };
-      if (op === '<') return { value: l.value < r.value };
-      if (op === '<=') return { value: l.value <= r.value };
-      if (op === '>') return { value: l.value > r.value };
-      if (op === '>=') return { value: l.value >= r.value };
-      if (op === '|') return { value: l.value | r.value };
-      if (op === '&') return { value: l.value & r.value };
-      if (op === '^') return { value: l.value ^ r.value };
-      if (op === '&&') return { value: l.value && r.value };
-      if (op === '||') return { value: l.value || r.value };
-    }      
+      else if ('test' in r) {
+        l = l.value;
+        if (op === '==') return { test: r.test, then: l == r.then, else: l == r.else };
+        if (op === '===') return { test: r.test, then: l === r.then, else: l === r.else };
+        if (op === '!=') return { test: r.test, then: l != r.then, else: l != r.else };
+        if (op === '!==') return { test: r.test, then: l !== r.then, else: l !== r.else };
+        if (op === '+') return { test: r.test, then: l + r.then, else: l + r.else };
+        if (op === '-') return { test: r.test, then: l - r.then, else: l - r.else };
+        if (op === '*') return { test: r.test, then: l * r.then, else: l * r.else };
+        if (op === '/') return { test: r.test, then: l / r.then, else: l / r.else };
+        if (op === '%') return { test: r.test, then: l % r.then, else: l % r.else };
+        if (op === '<') return { test: r.test, then: l < r.then, else: l < r.else };
+        if (op === '<=') return { test: r.test, then: l <= r.then, else: l <= r.else };
+        if (op === '>') return { test: r.test, then: l > r.then, else: l > r.else };
+        if (op === '>=') return { test: r.test, then: l >= r.then, else: l >= r.else };
+        if (op === '|') return { test: r.test, then: l | r.then, else: l | r.else };
+        if (op === '&') return { test: r.test, then: l & r.then, else: l & r.else };
+        if (op === '^') return { test: r.test, then: l ^ r.then, else: l ^ r.else };
+        if (op === '&&') return { test: r.test, then: l && r.then, else: l && r.else };
+        if (op === '||') return { test: r.test, then: l || r.then, else: l || r.else };
+      }
+      else {
+        if (op === '==') return { value: l.value == r.value };
+        if (op === '===') return { value: l.value === r.value };
+        if (op === '!=') return { value: l.value != r.value };
+        if (op === '!==') return { value: l.value !== r.value };
+        if (op === '+') {
+          const val = { value: l.value + r.value };
+          if (l.wildcards || r.wildcards)
+            val.wildcards = [...l.wildcards || [], ...r.wildcards || []];
+          return val;
+        }
+        if (op === '-') return { value: l.value - r.value };
+        if (op === '*') return { value: l.value * r.value };
+        if (op === '/') return { value: l.value / r.value };
+        if (op === '%') return { value: l.value % r.value };
+        if (op === '<') return { value: l.value < r.value };
+        if (op === '<=') return { value: l.value <= r.value };
+        if (op === '>') return { value: l.value > r.value };
+        if (op === '>=') return { value: l.value >= r.value };
+        if (op === '|') return { value: l.value | r.value };
+        if (op === '&') return { value: l.value & r.value };
+        if (op === '^') return { value: l.value ^ r.value };
+        if (op === '&&') return { value: l.value && r.value };
+        if (op === '||') return { value: l.value || r.value };
+      }
+    }
+    catch (e) {
+      return;
+    }
     return;
   },
   CallExpression (node, walk) {
@@ -422,17 +431,25 @@ const visitors = {
     const val = walk(node.argument);
     if (!val)
       return;
-    if ('value' in val && 'wildcards' in val === false) {
-      if (node.operator === '+') return { value: +val.value };
-      if (node.operator === '-') return { value: -val.value };
-      if (node.operator === '~') return { value: ~val.value };
-      if (node.operator === '!') return { value: !val.value };
+    // Evaluation can throw for known values, e.g. unary + on a BigInt
+    // ("Cannot convert a BigInt value to a number"). Any such error
+    // just means the expression is not statically computable.
+    try {
+      if ('value' in val && 'wildcards' in val === false) {
+        if (node.operator === '+') return { value: +val.value };
+        if (node.operator === '-') return { value: -val.value };
+        if (node.operator === '~') return { value: ~val.value };
+        if (node.operator === '!') return { value: !val.value };
+      }
+      else if ('test' in val && 'wildcards' in val === false) {
+        if (node.operator === '+') return { test: val.test, then: +val.then, else: +val.else };
+        if (node.operator === '-') return { test: val.test, then: -val.then, else: -val.else };
+        if (node.operator === '~') return { test: val.test, then: ~val.then, else: ~val.else };
+        if (node.operator === '!') return { test: val.test, then: !val.then, else: !val.else };
+      }
     }
-    else if ('test' in val && 'wildcards' in val === false) {
-      if (node.operator === '+') return { test: val.test, then: +val.then, else: +val.else };
-      if (node.operator === '-') return { test: val.test, then: -val.then, else: -val.else };
-      if (node.operator === '~') return { test: val.test, then: ~val.then, else: ~val.else };
-      if (node.operator === '!') return { test: val.test, then: !val.then, else: !val.else };
+    catch (e) {
+      return;
     }
     return;
   }

--- a/test/unit/static-eval-bigint/input.js
+++ b/test/unit/static-eval-bigint/input.js
@@ -1,0 +1,28 @@
+// Regression test: the loader tracks `counter = null` as a known binding
+// value, and previously crashed statically evaluating `counter + 1n`
+// ("TypeError: Cannot mix BigInt and other types") instead of treating
+// the expression as not statically computable.
+// Pattern from dd-trace's packages/dd-trace/src/appsec/downstream_requests.js.
+const KNUTH_FACTOR = 11400714819323199488n;
+const UINT64_MAX = (1n << 64n) - 1n;
+
+let counter;
+
+function enable () {
+  counter = 0n;
+}
+
+function disable () {
+  counter = null;
+}
+
+function next () {
+  counter = (counter + 1n) & UINT64_MAX;
+  return (counter * KNUTH_FACTOR) % UINT64_MAX;
+}
+
+// unary + on a known BigInt binding previously threw
+// "Cannot convert a BigInt value to a number"
+const coerced = +KNUTH_FACTOR ? 1 : 0;
+
+module.exports = { enable, disable, next, coerced };

--- a/test/unit/static-eval-bigint/output-coverage.js
+++ b/test/unit/static-eval-bigint/output-coverage.js
@@ -1,0 +1,74 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 635:
+/***/ ((module) => {
+
+// Regression test: the loader tracks `counter = null` as a known binding
+// value, and previously crashed statically evaluating `counter + 1n`
+// ("TypeError: Cannot mix BigInt and other types") instead of treating
+// the expression as not statically computable.
+// Pattern from dd-trace's packages/dd-trace/src/appsec/downstream_requests.js.
+const KNUTH_FACTOR = 11400714819323199488n;
+const UINT64_MAX = (1n << 64n) - 1n;
+
+let counter;
+
+function enable () {
+  counter = 0n;
+}
+
+function disable () {
+  counter = null;
+}
+
+function next () {
+  counter = (counter + 1n) & UINT64_MAX;
+  return (counter * KNUTH_FACTOR) % UINT64_MAX;
+}
+
+// unary + on a known BigInt binding previously threw
+// "Cannot convert a BigInt value to a number"
+const coerced = +KNUTH_FACTOR ? 1 : 0;
+
+module.exports = { enable, disable, next, coerced };
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(635);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/static-eval-bigint/output.js
+++ b/test/unit/static-eval-bigint/output.js
@@ -1,0 +1,74 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 635:
+/***/ ((module) => {
+
+// Regression test: the loader tracks `counter = null` as a known binding
+// value, and previously crashed statically evaluating `counter + 1n`
+// ("TypeError: Cannot mix BigInt and other types") instead of treating
+// the expression as not statically computable.
+// Pattern from dd-trace's packages/dd-trace/src/appsec/downstream_requests.js.
+const KNUTH_FACTOR = 11400714819323199488n;
+const UINT64_MAX = (1n << 64n) - 1n;
+
+let counter;
+
+function enable () {
+  counter = 0n;
+}
+
+function disable () {
+  counter = null;
+}
+
+function next () {
+  counter = (counter + 1n) & UINT64_MAX;
+  return (counter * KNUTH_FACTOR) % UINT64_MAX;
+}
+
+// unary + on a known BigInt binding previously threw
+// "Cannot convert a BigInt value to a number"
+const coerced = +KNUTH_FACTOR ? 1 : 0;
+
+module.exports = { enable, disable, next, coerced };
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(635);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;


### PR DESCRIPTION
## Problem

The static evaluator (`src/utils/static-eval.js`) applies JS operators directly to known values, but some of those operations can throw at evaluation time:

- **BigInt mixing**: `null + 1n` → `TypeError: Cannot mix BigInt and other types, use explicit conversions`
- **Unary `+` on a BigInt**: `+1n` → `TypeError: Cannot convert a BigInt value to a number`

The loader statically evaluates the RHS of every top-level-bound assignment (to track known bindings), so real-world code hits this. dd-trace 5's [`appsec/downstream_requests.js`](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/appsec/downstream_requests.js) does:

```js
let globalRequestCounter

function enable (_config) {
  globalRequestCounter = 0n
}

function disable () {
  globalRequestCounter = null   // <- registers null as the known binding value
}

function shouldSampleBody (req, outgoingUrl) {
  // evaluator computes `null + 1n` here and throws, crashing the build
  globalRequestCounter = (globalRequestCounter + 1n) & UINT64_MAX
  ...
}
```

The uncaught TypeError kills the whole compilation — e.g. `ncc build` of anything depending on `dd-trace@5` dies with:

```
TypeError: Cannot mix BigInt and other types, use explicit conversions
    at Object.BinaryExpression (.../relocate-loader.js.cache.js:...)
    at walk (...)
    at computePureStaticValue (...)
```

This blocks bumping dd-trace 4 → 5 in any ncc-bundled project (every ncc version is affected since they all bundle this loader).

## Fix

Wrap the operator application in `BinaryExpression` and `UnaryExpression` in try/catch, so a throwing expression is treated as **not statically computable** (the evaluator's existing "unknown value" semantics). `CallExpression` and `NewExpression` already handle evaluation errors exactly this way, so this follows established convention in the file. The diff is best viewed with whitespace ignored.

## Test

Added `test/unit/static-eval-bigint` reproducing the dd-trace pattern (known-`null` binding + `1n`, BigInt consts, and unary `+` on a known BigInt). Without the fix it crashes the build with the errors above; with the fix the module passes through untouched.

`npx jest test/index.test.js`: 85/85 pass. (`test/project.test.js` fails identically on unmodified `main` in my environment — pre-existing, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related

- Related to https://github.com/vercel/ncc/issues/1307
- Related to https://github.com/vercel/webpack-asset-relocator-loader/pull/208