### PR TITLE
fix: preserve relocated shorthand property keys

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -1205,7 +1205,7 @@ module.exports = async function (content, map) {
           }
         }
         // no static value -> see if we should emit the asset if it exists
-        emitStaticChildAsset();
+        emitStaticChildAsset(false, node);
       }
     }
   });
@@ -1302,7 +1302,17 @@ module.exports = async function (content, map) {
     return value instanceof URL ? fileURLToPath(value) : value.startsWith('file:') ? fileURLToPath(new URL(value)) : path.resolve(value);
   }
 
-  function emitStaticChildAsset (wrapRequire = false) {
+  function overwriteStaticChild (inlineString, staticParent) {
+    if (staticParent && staticParent.type === 'Property' && staticParent.shorthand && staticParent.value === staticChildNode) {
+      inlineString = code.substring(staticParent.key.start, staticParent.key.end) + ': ' + inlineString;
+      magicString.overwrite(staticParent.start, staticParent.end, inlineString);
+    }
+    else {
+      magicString.overwrite(staticChildNode.start, staticChildNode.end, inlineString);
+    }
+  }
+
+  function emitStaticChildAsset (wrapRequire = false, staticParent) {
     if (isAbsolutePathOrUrl(staticChildValue.value)) {
       let resolved;
       try { resolved = resolveAbsolutePathOrUrl(staticChildValue.value); }
@@ -1315,7 +1325,7 @@ module.exports = async function (content, map) {
           // -> require(require('bindings')(...))
           if (wrapRequire)
             inlineString = '__non_webpack_require__(' + inlineString + ')';
-          magicString.overwrite(staticChildNode.start, staticChildNode.end, inlineString);
+          overwriteStaticChild(inlineString, staticParent);
           transformed = true;
         }
       }
@@ -1333,9 +1343,9 @@ module.exports = async function (content, map) {
         const thenInlineString = emitAsset(resolvedThen);
         const elseInlineString = emitAsset(resolvedElse);
         if (thenInlineString && elseInlineString) {
-          magicString.overwrite(
-            staticChildNode.start, staticChildNode.end,
-            `${code.substring(staticChildValue.test.start, staticChildValue.test.end)} ? ${thenInlineString} : ${elseInlineString}`
+          overwriteStaticChild(
+            `${code.substring(staticChildValue.test.start, staticChildValue.test.end)} ? ${thenInlineString} : ${elseInlineString}`,
+            staticParent
           );
           transformed = true;
         }

--- a/test/fixtures/shorthand-property/input.js
+++ b/test/fixtures/shorthand-property/input.js
@@ -1,0 +1,17 @@
+let toolPath;
+
+if (process.env.RELOCATOR_TOOL_PATH) {
+  toolPath = process.env.RELOCATOR_TOOL_PATH;
+} else {
+  toolPath = require.resolve("./tool.js");
+}
+
+const conditionalToolPath = isHarmony
+  ? require.resolve("./tool.js")
+  : require.resolve("./other-tool.js");
+
+module.exports = {
+  name: "demo",
+  toolPath,
+  conditionalToolPath,
+};

--- a/test/fixtures/shorthand-property/other-tool.js
+++ b/test/fixtures/shorthand-property/other-tool.js
@@ -1,0 +1,1 @@
+module.exports = "other tool";

--- a/test/fixtures/shorthand-property/tool.js
+++ b/test/fixtures/shorthand-property/tool.js
@@ -1,0 +1,1 @@
+module.exports = "tool";

--- a/test/shorthand-property.test.js
+++ b/test/shorthand-property.test.js
@@ -1,0 +1,66 @@
+const path = require("path");
+const webpack = require("webpack");
+const MemoryFS = require("memory-fs");
+
+const relocateLoader = require("../");
+
+test("preserves shorthand properties for relocated asset bindings", async () => {
+  const outputFileSystem = new MemoryFS();
+  const compiler = webpack({
+    entry: path.resolve(__dirname, "fixtures/shorthand-property/input.js"),
+    mode: "production",
+    target: "node14",
+    optimization: { minimize: false, nodeEnv: false },
+    output: {
+      path: "/",
+      filename: "index.js",
+      libraryTarget: "commonjs2",
+    },
+    module: {
+      rules: [{
+        test: /\.(js|node)$/,
+        parser: { amd: false },
+        use: [{
+          loader: path.resolve(__dirname, "../"),
+          options: {
+            emitDirnameAll: true,
+            emitFilterAssetBaseAll: true,
+            filterAssetBase: path.resolve(__dirname, "fixtures"),
+            production: true,
+          },
+        }],
+      }],
+    },
+    plugins: [{
+      apply(compiler) {
+        compiler.hooks.compilation.tap("relocate-loader", compilation => {
+          relocateLoader.initAssetCache(compilation);
+        });
+      },
+    }],
+  });
+  compiler.outputFileSystem = outputFileSystem;
+
+  const stats = await new Promise((resolve, reject) => {
+    compiler.run((err, result) => err ? reject(err) : resolve(result));
+  });
+  if (stats.hasErrors()) {
+    throw new Error(stats.toString({ all: false, errors: true, errorDetails: true }));
+  }
+
+  const code = outputFileSystem.readFileSync("/index.js", "utf8");
+  const bundledModule = { exports: {} };
+  new Function("module", "exports", "require", "__dirname", "isHarmony", code)(
+    bundledModule,
+    bundledModule.exports,
+    require,
+    "",
+    true,
+  );
+
+  expect(bundledModule.exports.name).toBe("demo");
+  expect(bundledModule.exports.toolPath).toBe("/tool.js");
+  expect(bundledModule.exports.conditionalToolPath).toBe("/tool.js");
+  expect(outputFileSystem.existsSync("/tool.js")).toBe(true);
+  expect(outputFileSystem.existsSync("/other-tool.js")).toBe(true);
+});


### PR DESCRIPTION
## Summary

When a relocated asset binding is used as a shorthand object property, the loader replaces the shared key/value identifier with an asset expression. This produces invalid object syntax and causes webpack to fail parsing the transformed module.

This change expands only relocated shorthand properties into explicit `key: value` form before inserting the asset expression. Existing identifier-read handling remains unchanged, including shorthand `require` behavior. The same handling covers both direct and conditional asset paths.

## Testing

- Added a regression that fails on the previous implementation and verifies the compiled bundle, exported property values, and emitted assets.
- `yarn test` - 86 tests passed.
- `yarn test-coverage` - 86 tests passed and coverage thresholds were met.

Fixes #209