### PR TITLE
chore(deps): bump lodash to 4.18.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4649,9 +4649,9 @@ lodash.uniqby@^4.7.0:
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
 lodash@^4.17.11, lodash@^4.17.19, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lru-cache@^10.0.1:
   version "10.4.3"


### PR DESCRIPTION
Supersedes #214, taking only the lodash half of the grouped update.

## Why #214's CI fails

#214 bumps two lockfile-only deps: **webpack 5.76.0 → 5.104.1** and **lodash 4.17.21 → 4.18.1** (both resolve within existing `package.json` ranges; webpack is a devDependency, lodash is transitive).

The test suite compares the *entire webpack-generated bundle byte-for-byte* against checked-in fixtures (`test/unit/*/output.js`, plus expected chunk filenames in `test/project-chunking`). webpack 5.104 changes codegen — method-shorthand module rendering in `__webpack_modules__`, different module ids, changed IIFE wrapping — so **71 of 85 tests fail on every OS**, e.g.:

```diff
-/***/ 147:
-/***/ ((module) => {
+/***/ 896
+(module) {
```

The loader itself still relocates assets correctly under webpack 5.104; the mismatches are formatting/ids. But accepting the bump would mean regenerating ~71 fixtures **twice** (`output.js` + `output-coverage.js`) plus the project-chunking expectations — a huge, hard-to-review diff.

## This PR (path of least change)

- ✅ **lodash 4.17.21 → 4.18.1** — same 3-line lockfile entry as in #214. Resolves the security advisories that triggered the group ([GHSA-f23m-r3pf-42rh](https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh) `_.unset`/`_.omit` prototype pollution, [GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800 `_.template` code injection). lodash is dev-tooling-only here and appears in no fixture output.
- ❌ **webpack stays at 5.76.0** — bumping it requires regenerating every fixture, which deserves its own deliberate PR. Exposure is limited: webpack is a devDependency (build/test-time only).

## Verification

`yarn test` and `yarn test-coverage` both pass **85/85** locally on Node 22 with webpack 5.76.0 + lodash 4.18.1 (reproduced #214's 71 failures locally first, then confirmed green after dropping the webpack bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)